### PR TITLE
Remove java8 support

### DIFF
--- a/kin-sdk-core/build.gradle
+++ b/kin-sdk-core/build.gradle
@@ -24,10 +24,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/kin-sdk-core/src/main/java/kin/sdk/core/AbstractKinAccount.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/AbstractKinAccount.java
@@ -1,25 +1,39 @@
 package kin.sdk.core;
 
 import java.math.BigDecimal;
+import java.util.concurrent.Callable;
 
 abstract class AbstractKinAccount implements KinAccount {
 
     @Override
     public Request<TransactionId> sendTransaction(final String publicAddress, final String passphrase,
         final BigDecimal amount) {
-        return new Request<>(() -> sendTransactionSync(publicAddress, passphrase, amount));
+        return new Request<>(new Callable<TransactionId>() {
+            @Override
+            public TransactionId call() throws Exception {
+                return sendTransactionSync(publicAddress, passphrase, amount);
+            }
+        });
     }
 
     @Override
     public Request<Balance> getBalance() {
-        return new Request<>(this::getBalanceSync);
+        return new Request<>(new Callable<Balance>() {
+            @Override
+            public Balance call() throws Exception {
+                return getBalanceSync();
+            }
+        });
     }
 
     @Override
-    public Request<Void> activate(String passphrase) {
-        return new Request<>(() -> {
-            activateSync(passphrase);
-            return null;
+    public Request<Void> activate(final String passphrase) {
+        return new Request<>(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                activateSync(passphrase);
+                return null;
+            }
         });
     }
 

--- a/kin-sdk-core/src/test/java/kin/sdk/core/AccountActivatorTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/AccountActivatorTest.java
@@ -35,6 +35,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.stellar.sdk.KeyPair;
@@ -84,7 +86,12 @@ public class AccountActivatorTest {
     private void mockKeyStoreResponse() {
         when(mockKeyStore.decryptAccount(any(Account.class), anyString()))
             .thenAnswer(
-                invocation -> KeyPair.fromSecretSeed(((Account) invocation.getArguments()[0]).getEncryptedSeed()));
+                new Answer<Object>() {
+                    @Override
+                    public Object answer(InvocationOnMock invocation) throws Throwable {
+                        return KeyPair.fromSecretSeed(((Account) invocation.getArguments()[0]).getEncryptedSeed());
+                    }
+                });
     }
 
     @Test

--- a/kin-sdk-core/src/test/java/kin/sdk/core/BalanceQueryTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/BalanceQueryTest.java
@@ -4,18 +4,18 @@ import static kin.sdk.core.TestUtils.enqueueEmptyResponse;
 import static kin.sdk.core.TestUtils.generateSuccessMockResponse;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import kin.sdk.core.ServiceProvider.KinAsset;
-import kin.sdk.core.exception.AccountNotFoundException;
 import kin.sdk.core.exception.AccountNotActivatedException;
+import kin.sdk.core.exception.AccountNotFoundException;
 import kin.sdk.core.exception.OperationFailedException;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.SocketPolicy;
+import org.hamcrest.Matchers;
 import org.hamcrest.beans.HasPropertyWithValue;
 import org.junit.Assert;
 import org.junit.Before;
@@ -115,7 +115,7 @@ public class BalanceQueryTest {
         );
 
         expectedEx.expect(OperationFailedException.class);
-        expectedEx.expectCause(instanceOf(HttpResponseException.class));
+        expectedEx.expectCause(Matchers.<Throwable>instanceOf(HttpResponseException.class));
         getBalance(ACCOUNT_ID_KIN_ISSUER, ACCOUNT_ID);
     }
 

--- a/kin-sdk-core/src/test/java/kin/sdk/core/ClientWrapperTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/ClientWrapperTest.java
@@ -56,7 +56,9 @@ public class ClientWrapperTest {
         String expectedAccountId = "GDKJAMCTGZGD6KM7RBEII6QUYAHQQUGERXKM3ESHBX2UUNTNAVNB3OGX";
         BigDecimal expectedAmount = new BigDecimal("12.2");
         TransactionId expectedTransactionId = new TransactionIdImpl("myId");
-        when(mockTransactionSender.sendTransaction(any(), any(), any(), any())).thenReturn(expectedTransactionId);
+        when(mockTransactionSender
+            .sendTransaction((Account) any(), (String) any(), (String) any(), (BigDecimal) any()))
+            .thenReturn(expectedTransactionId);
 
         TransactionId transactionId = clientWrapper
             .sendTransaction(expectedFrom, expectedPassphrase, expectedAccountId, expectedAmount);
@@ -71,7 +73,7 @@ public class ClientWrapperTest {
         KeyPair keyPair = KeyPair.random();
         Account expectedFrom = new Account(new String(keyPair.getSecretSeed()), keyPair.getAccountId());
         Balance expectedBalance = new BalanceImpl(new BigDecimal("11.0"));
-        when(mockBalanceQuery.getBalance(any())).thenReturn(expectedBalance);
+        when(mockBalanceQuery.getBalance((Account) any())).thenReturn(expectedBalance);
 
         Balance balance = clientWrapper.getBalance(expectedFrom);
 

--- a/kin-sdk-core/src/test/java/kin/sdk/core/KinAccountImplTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/KinAccountImplTest.java
@@ -54,7 +54,8 @@ public class KinAccountImplTest {
         BigDecimal expectedAmount = new BigDecimal("12.2");
         TransactionId expectedTransactionId = new TransactionIdImpl("myId");
 
-        when(mockClientWrapper.sendTransaction(any(), any(), any(), any())).thenReturn(expectedTransactionId);
+        when(mockClientWrapper.sendTransaction((Account) any(), (String) any(), (String) any(), (BigDecimal) any()))
+            .thenReturn(expectedTransactionId);
 
         TransactionId transactionId = kinAccount
             .sendTransactionSync(expectedAccountId, expectedPassphrase, expectedAmount);
@@ -69,7 +70,7 @@ public class KinAccountImplTest {
         initWithRandomAccount();
 
         Balance expectedBalance = new BalanceImpl(new BigDecimal("11.0"));
-        when(mockClientWrapper.getBalance(any())).thenReturn(expectedBalance);
+        when(mockClientWrapper.getBalance((Account) any())).thenReturn(expectedBalance);
 
         Balance balance = kinAccount.getBalanceSync();
 

--- a/kin-sdk-core/src/test/java/kin/sdk/core/KinClientTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/KinClientTest.java
@@ -20,6 +20,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.stellar.sdk.KeyPair;
 
 @SuppressWarnings("deprecation")
@@ -36,7 +38,12 @@ public class KinClientTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        when(mockClientWrapper.getKeyStore()).thenAnswer(invocation -> fakeKeyStore);
+        when(mockClientWrapper.getKeyStore()).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return fakeKeyStore;
+            }
+        });
     }
 
     @Test

--- a/kin-sdk-core/src/test/java/kin/sdk/core/TransactionSenderTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/TransactionSenderTest.java
@@ -22,8 +22,8 @@ import java.math.BigDecimal;
 import java.net.SocketTimeoutException;
 import java.util.concurrent.TimeUnit;
 import kin.sdk.core.ServiceProvider.KinAsset;
-import kin.sdk.core.exception.AccountNotFoundException;
 import kin.sdk.core.exception.AccountNotActivatedException;
+import kin.sdk.core.exception.AccountNotFoundException;
 import kin.sdk.core.exception.OperationFailedException;
 import kin.sdk.core.exception.TransactionFailedException;
 import okhttp3.mockwebserver.MockResponse;
@@ -38,6 +38,8 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.stellar.sdk.FormatException;
@@ -90,7 +92,12 @@ public class TransactionSenderTest {
     private void mockKeyStoreResponse() {
         when(mockKeyStore.decryptAccount(any(Account.class), anyString()))
             .thenAnswer(
-                invocation -> KeyPair.fromSecretSeed(((Account) invocation.getArguments()[0]).getEncryptedSeed()));
+                new Answer<Object>() {
+                    @Override
+                    public Object answer(InvocationOnMock invocation) throws Throwable {
+                        return KeyPair.fromSecretSeed(((Account) invocation.getArguments()[0]).getEncryptedSeed());
+                    }
+                });
     }
 
     @Test


### PR DESCRIPTION
remove Java8 support, as if we are using Java 8 support in SDK (using the d8 compiler and android gradle plugin 3+), that will enforce host app to use Java 8 support as well (specifically with android gradle plugin 3.0.0+) otherwise, compilation will fail