### PR TITLE
Keystore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 env:
   global:
     - ANDROID_API_LEVEL=26
-    - EMULATOR_API_LEVEL=16
+    - EMULATOR_API_LEVEL=23
 
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 env:
   global:
     - ANDROID_API_LEVEL=26
-    - EMULATOR_API_LEVEL=23
+    - EMULATOR_API_LEVEL=16
 
 android:
   components:

--- a/kin-sdk-core/src/androidTest/java/kin/sdk/core/EncryptorImplV18Test.java
+++ b/kin-sdk-core/src/androidTest/java/kin/sdk/core/EncryptorImplV18Test.java
@@ -1,0 +1,51 @@
+package kin.sdk.core;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assume.assumeTrue;
+
+import android.os.Build;
+import android.os.Build.VERSION_CODES;
+import android.support.test.InstrumentationRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EncryptorImplV18Test {
+
+    private Encryptor cryptor;
+
+    @Before
+    public void setup() {
+        checkIfTestShouldRun();
+
+        cryptor = new EncryptorImplV18(InstrumentationRegistry.getTargetContext());
+    }
+
+    private void checkIfTestShouldRun() {
+        //run only on sdk >= 18 devices
+        assumeTrue(Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2);
+    }
+
+    @Test
+    public void encryptThenDecrypt_Success() throws Exception {
+        String secretSeed = "SDL34EFTWFPIVJLUYSCVZJFYPYLIGFHDYG5VKOVBQYLU6H4OWRPETCAE";
+        String encryptedSecret = cryptor.encrypt(secretSeed);
+        String actualDecryptedSeed = cryptor.decrypt(encryptedSecret);
+        assertEquals(secretSeed, actualDecryptedSeed);
+    }
+
+    @Test
+    public void encrypt_VerifyRandomness() throws Exception {
+        String encryptedSecret1 = cryptor.encrypt("SCIZAKL7BH7XHL2Y3HZ6SOCMKMTTMHASD5LRHJJKZOHBQARTCFNWAPEF");
+        String encryptedSecret2 = cryptor.encrypt("SCIZAKL7BH7XHL2Y3HZ6SOCMKMTTMHASD5LRHJJKZOHBQARTCFNWAPEF");
+        assertNotEquals(encryptedSecret1, encryptedSecret2);
+    }
+
+    @Test
+    public void decrypt_NotEqualsToSource() throws Exception {
+        String secret = "SCJFLXKUY6VQT2LYSP6XDP23WNEP5OITSC3LZEJUJO7GFZM7QLDF2BCN";
+        String encryptedSecret = cryptor.encrypt(secret);
+        assertNotEquals(encryptedSecret, secret);
+    }
+
+}

--- a/kin-sdk-core/src/androidTest/java/kin/sdk/core/EncryptorImplV23Test.java
+++ b/kin-sdk-core/src/androidTest/java/kin/sdk/core/EncryptorImplV23Test.java
@@ -2,21 +2,27 @@ package kin.sdk.core;
 
 import static junit.framework.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assume.assumeTrue;
 
-import android.content.Context;
-import android.support.test.InstrumentationRegistry;
+import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import org.junit.Before;
 import org.junit.Test;
 
-public class EncryptorTest {
+public class EncryptorImplV23Test {
 
     private Encryptor cryptor;
 
     @Before
     public void setup() {
-        Context context = InstrumentationRegistry.getTargetContext();
-        cryptor = EncryptorFactory
-            .create(context, new SharedPrefStore(context.getSharedPreferences("TEST", Context.MODE_PRIVATE)));
+        checkIfTestShouldRun();
+
+        cryptor = new EncryptorImplV23();
+    }
+
+    private void checkIfTestShouldRun() {
+        //run only on sdk >= 23 devices
+        assumeTrue(Build.VERSION.SDK_INT >= VERSION_CODES.M);
     }
 
     @Test

--- a/kin-sdk-core/src/androidTest/java/kin/sdk/core/EncryptorTest.java
+++ b/kin-sdk-core/src/androidTest/java/kin/sdk/core/EncryptorTest.java
@@ -1,0 +1,44 @@
+package kin.sdk.core;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EncryptorTest {
+
+    private Encryptor cryptor;
+
+    @Before
+    public void setup() {
+        Context context = InstrumentationRegistry.getTargetContext();
+        cryptor = EncryptorFactory
+            .create(context, new SharedPrefStore(context.getSharedPreferences("TEST", Context.MODE_PRIVATE)));
+    }
+
+    @Test
+    public void encryptThenDecrypt_Success() throws Exception {
+        String secretSeed = "SDL34EFTWFPIVJLUYSCVZJFYPYLIGFHDYG5VKOVBQYLU6H4OWRPETCAE";
+        String encryptedSecret = cryptor.encrypt(secretSeed);
+        String actualDecryptedSeed = cryptor.decrypt(encryptedSecret);
+        assertEquals(secretSeed, actualDecryptedSeed);
+    }
+
+    @Test
+    public void encrypt_VerifyRandomness() throws Exception {
+        String encryptedSecret1 = cryptor.encrypt("SCIZAKL7BH7XHL2Y3HZ6SOCMKMTTMHASD5LRHJJKZOHBQARTCFNWAPEF");
+        String encryptedSecret2 = cryptor.encrypt("SCIZAKL7BH7XHL2Y3HZ6SOCMKMTTMHASD5LRHJJKZOHBQARTCFNWAPEF");
+        assertNotEquals(encryptedSecret1, encryptedSecret2);
+    }
+
+    @Test
+    public void decrypt_NotEqualsToSource() throws Exception {
+        String secret = "SCJFLXKUY6VQT2LYSP6XDP23WNEP5OITSC3LZEJUJO7GFZM7QLDF2BCN";
+        String encryptedSecret = cryptor.encrypt(secret);
+        assertNotEquals(encryptedSecret, secret);
+    }
+
+}

--- a/kin-sdk-core/src/androidTest/java/kin/sdk/core/KinClientIntegrationTest.java
+++ b/kin-sdk-core/src/androidTest/java/kin/sdk/core/KinClientIntegrationTest.java
@@ -12,6 +12,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 
 import android.support.test.InstrumentationRegistry;
+import kin.sdk.core.exception.CreateAccountException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -230,7 +231,7 @@ public class KinClientIntegrationTest {
     }
 
     @Test
-    public void wipeout() {
+    public void wipeout() throws CreateAccountException {
         kinClient.addAccount(PASSPHRASE);
         kinClient.addAccount(PASSPHRASE);
         kinClient.addAccount(PASSPHRASE);

--- a/kin-sdk-core/src/main/java/kin/sdk/core/AccountActivator.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/AccountActivator.java
@@ -46,7 +46,7 @@ class AccountActivator {
             } else {
                 throw new OperationFailedException(httpError);
             }
-        } catch (IOException e) {
+        } catch (IOException | CryptoException e) {
             throw new OperationFailedException(e);
         }
     }
@@ -67,13 +67,13 @@ class AccountActivator {
     }
 
     private SubmitTransactionResponse sendAllowKinTrustOperation(Account account, String passphrase,
-        AccountResponse accountResponse) throws IOException {
+        AccountResponse accountResponse) throws IOException, CryptoException {
         Transaction allowKinTrustTransaction = new Transaction.Builder(accountResponse).addOperation(
             new ChangeTrustOperation.Builder(kinAsset.getStellarAsset(), TRUST_NO_LIMIT_VALUE)
                 .build()
         )
             .build();
-        allowKinTrustTransaction.sign(keyStore.decryptAccount(account, passphrase));
+        allowKinTrustTransaction.sign(keyStore.decryptAccount(account));
         return server.submitTransaction(allowKinTrustTransaction);
     }
 

--- a/kin-sdk-core/src/main/java/kin/sdk/core/ClientWrapper.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/ClientWrapper.java
@@ -17,6 +17,7 @@ import org.stellar.sdk.Server;
  */
 class ClientWrapper {
 
+    private static final String STORE_NAME = "KinKeyStore";
     private final ServiceProvider serviceProvider;
     private final KeyStore keyStore;
     private final TransactionSender transactionSender;
@@ -52,7 +53,9 @@ class ClientWrapper {
     }
 
     private KeyStore initKeyStore(Context context) {
-        return new KeyStoreImpl(context);
+        SharedPrefStore store = new SharedPrefStore(context.getSharedPreferences(STORE_NAME, Context.MODE_PRIVATE));
+        Encryptor encryptor = EncryptorFactory.create(context, store);
+        return new KeyStoreImpl(store, encryptor);
     }
 
     void wipeoutAccounts() {

--- a/kin-sdk-core/src/main/java/kin/sdk/core/CryptoException.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/CryptoException.java
@@ -1,0 +1,9 @@
+package kin.sdk.core;
+
+
+class CryptoException extends Exception {
+
+    CryptoException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/Encryptor.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/Encryptor.java
@@ -1,0 +1,8 @@
+package kin.sdk.core;
+
+interface Encryptor {
+
+    String encrypt(String secret) throws CryptoException;
+
+    String decrypt(String encryptedSecret) throws CryptoException;
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorFactory.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorFactory.java
@@ -1,0 +1,43 @@
+package kin.sdk.core;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Build.VERSION_CODES;
+
+class EncryptorFactory {
+
+    private static final String VERSION_KEY = "encryptor_ver";
+    private static final String VER_23 = "23";
+    private static final String VER_18 = "18";
+    private static final String VER_16 = "16";
+
+    //no instances
+    private EncryptorFactory() {
+    }
+
+    static Encryptor create(Context context, Store store) {
+        String versionString = store.getString(VERSION_KEY);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (VER_18.equals(versionString)) {
+                store.saveString(VERSION_KEY, VER_18);
+                return new EncryptorImplV18(context.getApplicationContext());
+            } else if (VER_16.equals(versionString)) {
+                store.saveString(VERSION_KEY, VER_16);
+                return new EncryptorImplV16();
+            }
+            store.saveString(VERSION_KEY, "23");
+            return new EncryptorImplV23();
+        } else if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
+            if (VER_16.equals(versionString)) {
+                store.saveString(VERSION_KEY, VER_16);
+                return new EncryptorImplV16();
+            }
+            store.saveString(VERSION_KEY, VER_18);
+            return new EncryptorImplV18(context.getApplicationContext());
+        } else {
+            store.saveString(VERSION_KEY, "16");
+            return new EncryptorImplV16();
+        }
+    }
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorFactory.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorFactory.java
@@ -1,45 +1,76 @@
 package kin.sdk.core;
 
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.Build.VERSION_CODES;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
+@SuppressLint("NewApi")
 class EncryptorFactory {
 
     private static final String VERSION_KEY = "encryptor_ver";
-    private static final String VER_23 = "23";
-    private static final String VER_18 = "18";
-    private static final String VER_16 = "16";
 
     //no instances
     private EncryptorFactory() {
     }
 
+    @TargetApi(VERSION_CODES.M)
     static Encryptor create(Context context, Store store) {
         String versionString = store.getString(VERSION_KEY);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            //handle android version upgrades, fallback to old encyrptor version if already exists, o.w. older
-            //keys cannot be restored
-            if (VER_18.equals(versionString)) {
-                store.saveString(VERSION_KEY, VER_18);
-                return new EncryptorImplV18(context.getApplicationContext());
-            } else if (VER_16.equals(versionString)) {
-                store.saveString(VERSION_KEY, VER_16);
-                return new EncryptorImplV16();
-            }
-            store.saveString(VERSION_KEY, VER_23);
-            return new EncryptorImplV23();
-        } else if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
-            if (VER_16.equals(versionString)) {
-                store.saveString(VERSION_KEY, VER_16);
-                return new EncryptorImplV16();
-            }
-            store.saveString(VERSION_KEY, VER_18);
-            return new EncryptorImplV18(context.getApplicationContext());
-        } else {
-            store.saveString(VERSION_KEY, VER_16);
-            return new EncryptorImplV16();
+        Encryptor encryptor = createEncryptorAccordingToSavedVersion(context, versionString, store);
+        if (encryptor == null) {
+            encryptor = createEncryptorByAndroidVersion(context, store);
         }
+
+        return encryptor;
+    }
+
+    @Nullable
+    private static Encryptor createEncryptorAccordingToSavedVersion(Context context, String versionString,
+        Store store) {
+        //handle android version upgrades, keystore version will be saved first time keystore is created,
+        //after upgrade we'll fallback to old encyrptor version if already exists, o.w. older keys cannot be restored
+        if (String.valueOf(VERSION_CODES.M).equals(versionString)) {
+            return createVersion23(store);
+        } else if (String.valueOf(VERSION_CODES.JELLY_BEAN_MR2).equals(versionString)) {
+            return createVersion18(context, store);
+        } else if (String.valueOf(VERSION_CODES.JELLY_BEAN).equals(versionString)) {
+            return createVersion16(store);
+        }
+        return null;
+    }
+
+    @NonNull
+    private static Encryptor createEncryptorByAndroidVersion(Context context, Store store) {
+        //at fresh start, encryptor will be created according Android version
+        if (Build.VERSION.SDK_INT >= VERSION_CODES.M) {
+            return createVersion23(store);
+        } else if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
+            return createVersion18(context, store);
+        } else {
+            return createVersion16(store);
+        }
+    }
+
+    @NonNull
+    private static Encryptor createVersion16(Store store) {
+        store.saveString(VERSION_KEY, String.valueOf(VERSION_CODES.JELLY_BEAN));
+        return new EncryptorImplV16();
+    }
+
+    @NonNull
+    private static Encryptor createVersion18(Context context, Store store) {
+        store.saveString(VERSION_KEY, String.valueOf(VERSION_CODES.JELLY_BEAN_MR2));
+        return new EncryptorImplV18(context.getApplicationContext());
+    }
+
+    @NonNull
+    private static Encryptor createVersion23(Store store) {
+        store.saveString(VERSION_KEY, String.valueOf(VERSION_CODES.M));
+        return new EncryptorImplV23();
     }
 }

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorFactory.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorFactory.java
@@ -19,6 +19,8 @@ class EncryptorFactory {
         String versionString = store.getString(VERSION_KEY);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            //handle android version upgrades, fallback to old encyrptor version if already exists, o.w. older
+            //keys cannot be restored
             if (VER_18.equals(versionString)) {
                 store.saveString(VERSION_KEY, VER_18);
                 return new EncryptorImplV18(context.getApplicationContext());
@@ -26,7 +28,7 @@ class EncryptorFactory {
                 store.saveString(VERSION_KEY, VER_16);
                 return new EncryptorImplV16();
             }
-            store.saveString(VERSION_KEY, "23");
+            store.saveString(VERSION_KEY, VER_23);
             return new EncryptorImplV23();
         } else if (Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
             if (VER_16.equals(versionString)) {
@@ -36,7 +38,7 @@ class EncryptorFactory {
             store.saveString(VERSION_KEY, VER_18);
             return new EncryptorImplV18(context.getApplicationContext());
         } else {
-            store.saveString(VERSION_KEY, "16");
+            store.saveString(VERSION_KEY, VER_16);
             return new EncryptorImplV16();
         }
     }

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV16.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV16.java
@@ -1,0 +1,18 @@
+package kin.sdk.core;
+
+
+/**
+ * UNSAFE no-op encryptor for below api 18, it will do no encryption
+ */
+public class EncryptorImplV16 implements Encryptor {
+
+    @Override
+    public String encrypt(String secret) throws CryptoException {
+        return secret;
+    }
+
+    @Override
+    public String decrypt(String encryptedSecret) throws CryptoException {
+        return encryptedSecret;
+    }
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV16.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV16.java
@@ -4,7 +4,7 @@ package kin.sdk.core;
 /**
  * UNSAFE no-op encryptor for below api 18, it will do no encryption
  */
-public class EncryptorImplV16 implements Encryptor {
+class EncryptorImplV16 implements Encryptor {
 
     @Override
     public String encrypt(String secret) throws CryptoException {

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV18.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV18.java
@@ -1,0 +1,123 @@
+package kin.sdk.core;
+
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.Build.VERSION_CODES;
+import android.security.KeyPairGeneratorSpec;
+import android.util.Base64;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PublicKey;
+import java.security.UnrecoverableEntryException;
+import java.util.ArrayList;
+import java.util.Calendar;
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.NoSuchPaddingException;
+import javax.security.auth.x500.X500Principal;
+
+class EncryptorImplV18 implements Encryptor {
+
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+    private static final String RSA_MODE = "RSA/ECB/PKCS1Padding";
+    private static final String CIPHER_PROVIDER = "AndroidOpenSSL";
+    private static final String ALIAS = "KinKeyStore";
+
+    private final Context context;
+
+    EncryptorImplV18(Context context) {
+        this.context = context;
+    }
+
+    public String encrypt(String secret) throws CryptoException {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+            keyStore.load(null);
+            return rsaEncrypt(ALIAS, secret);
+        } catch (Exception e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    public String decrypt(String encryptedSecret) throws CryptoException {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+            keyStore.load(null);
+            return rsaDecrypt(ALIAS
+                , encryptedSecret, keyStore);
+        } catch (Exception e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    private String rsaEncrypt(String alias, String secret) throws Exception {
+        KeyPair rsaKeys = generateRsaPair(alias);
+        byte[] encryptedBytes = performEncryption(secret.getBytes("UTF-8"), rsaKeys.getPublic());
+        return Base64.encodeToString(encryptedBytes, Base64.DEFAULT);
+    }
+
+    @TargetApi(VERSION_CODES.JELLY_BEAN_MR2)
+    private KeyPair generateRsaPair(String alias)
+        throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+        Calendar start = Calendar.getInstance();
+        Calendar end = Calendar.getInstance();
+        end.add(Calendar.YEAR, 30);
+        KeyPairGeneratorSpec spec = new KeyPairGeneratorSpec.Builder(context)
+            .setAlias(alias)
+            .setSubject(new X500Principal("CN=" + alias))
+            .setSerialNumber(BigInteger.TEN)
+            .setStartDate(start.getTime())
+            .setEndDate(end.getTime())
+            .build();
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA", ANDROID_KEY_STORE);
+        kpg.initialize(spec);
+        return kpg.generateKeyPair();
+    }
+
+    private byte[] performEncryption(byte[] secretBytes, PublicKey publicKey)
+        throws NoSuchPaddingException, NoSuchAlgorithmException, NoSuchProviderException, InvalidKeyException, IOException {
+        Cipher input = Cipher.getInstance(RSA_MODE, CIPHER_PROVIDER);
+        input.init(Cipher.ENCRYPT_MODE, publicKey);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        CipherOutputStream cipherOutputStream = new CipherOutputStream(
+            outputStream, input);
+        cipherOutputStream.write(secretBytes);
+        cipherOutputStream.close();
+        return outputStream.toByteArray();
+    }
+
+    private String rsaDecrypt(String alias, String encryptedSecret64, KeyStore keyStore)
+        throws UnrecoverableEntryException, NoSuchAlgorithmException, KeyStoreException, InvalidKeyException, IOException, NoSuchProviderException, NoSuchPaddingException {
+        KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry) keyStore.getEntry(alias, null);
+
+        Cipher output = Cipher.getInstance(RSA_MODE, CIPHER_PROVIDER);
+        output.init(Cipher.DECRYPT_MODE, privateKeyEntry.getPrivateKey());
+        byte[] encryptedSecretBytes = Base64.decode(encryptedSecret64, Base64.DEFAULT);
+        CipherInputStream cipherInputStream = new CipherInputStream(
+            new ByteArrayInputStream(encryptedSecretBytes), output);
+        ArrayList<Byte> values = new ArrayList<>();
+        int nextByte;
+        while ((nextByte = cipherInputStream.read()) != -1) {
+            values.add((byte) nextByte);
+        }
+
+        byte[] bytes = new byte[values.size()];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = values.get(i);
+        }
+        return new String(bytes, 0, bytes.length, "UTF-8");
+    }
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV23.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV23.java
@@ -36,7 +36,7 @@ class EncryptorImplV23 implements Encryptor {
         try {
             KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
             keyStore.load(null);
-            return aesEncrypt(keyStore, ALIAS, secret);
+            return aesEncrypt(keyStore, secret);
         } catch (Exception e) {
             throw new CryptoException(e);
         }
@@ -67,31 +67,31 @@ class EncryptorImplV23 implements Encryptor {
     private String performDecryption(KeyStore keyStore, byte[] ivBytes, byte[] encryptedSecretBytes) throws Exception {
         final Cipher cipher = Cipher.getInstance(AES_MODE);
         final GCMParameterSpec spec = new GCMParameterSpec(KEY_SIZE, ivBytes);
-        cipher.init(Cipher.DECRYPT_MODE, getSecretKey(ALIAS, keyStore), spec);
+        cipher.init(Cipher.DECRYPT_MODE, getSecretKey(keyStore), spec);
 
         byte[] decryptedBytes = cipher.doFinal(encryptedSecretBytes);
         return new String(decryptedBytes, 0, decryptedBytes.length, "UTF-8");
     }
 
-    private SecretKey getSecretKey(final String alias, KeyStore keyStore) throws NoSuchAlgorithmException,
+    private SecretKey getSecretKey(KeyStore keyStore) throws NoSuchAlgorithmException,
         UnrecoverableEntryException, KeyStoreException {
-        return ((KeyStore.SecretKeyEntry) keyStore.getEntry(alias, null)).getSecretKey();
+        return ((KeyStore.SecretKeyEntry) keyStore.getEntry(ALIAS, null)).getSecretKey();
     }
 
-    private String aesEncrypt(KeyStore keystore, String alias, String secret) throws Exception {
+    private String aesEncrypt(KeyStore keystore, String secret) throws Exception {
         SecretKey secretKey;
-        if (keystore.containsAlias(alias)) {
-            secretKey = getSecretKey(alias, keystore);
+        if (keystore.containsAlias(ALIAS)) {
+            secretKey = getSecretKey(keystore);
         } else {
-            secretKey = generateAESSecretKey(alias);
+            secretKey = generateAESSecretKey();
         }
         return performEncryption(secretKey, secret.getBytes("UTF-8"));
     }
 
-    private SecretKey generateAESSecretKey(String alias) throws Exception {
+    private SecretKey generateAESSecretKey() throws Exception {
         KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
         keyGenerator.init(
-            new KeyGenParameterSpec.Builder(alias,
+            new KeyGenParameterSpec.Builder(ALIAS,
                 KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
                 .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                 .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)

--- a/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV23.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/EncryptorImplV23.java
@@ -1,0 +1,132 @@
+package kin.sdk.core;
+
+
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
+import android.util.Base64;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.UnrecoverableEntryException;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+@RequiresApi(api = Build.VERSION_CODES.M)
+class EncryptorImplV23 implements Encryptor {
+
+    private static final String ANDROID_KEY_STORE = "AndroidKeyStore";
+    private static final String AES_MODE = "AES/GCM/NoPadding";
+    private static final String ALIAS = "KinKeyStore";
+    private static final String JSON_IV = "iv";
+    private static final String JSON_CIPHER = "cipher";
+    private static final int KEY_SIZE = 128;
+
+    EncryptorImplV23() {
+    }
+
+    @Override
+    public String encrypt(String secret) throws CryptoException {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+            keyStore.load(null);
+            return aesEncrypt(ALIAS, secret);
+        } catch (Exception e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    @Override
+    public String decrypt(String encryptedSecret) throws CryptoException {
+        try {
+            KeyStore keyStore = KeyStore.getInstance(ANDROID_KEY_STORE);
+            keyStore.load(null);
+            return aesDecrypt(encryptedSecret, keyStore);
+        } catch (Exception e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    private String aesDecrypt(String encryptedSecret, KeyStore keyStore)
+        throws UnrecoverableEntryException, NoSuchAlgorithmException, KeyStoreException,
+        NoSuchProviderException, NoSuchPaddingException, InvalidKeyException, IOException,
+        BadPaddingException, IllegalBlockSizeException, InvalidAlgorithmParameterException, JSONException {
+        JSONObject jsonObject = new JSONObject(encryptedSecret);
+        String ivBase64String = jsonObject.getString(JSON_IV);
+        String cipherBase64String = jsonObject.getString(JSON_CIPHER);
+        byte[] ivBytes = Base64.decode(ivBase64String, Base64.DEFAULT);
+        byte[] encryptedSecretBytes = Base64.decode(cipherBase64String, Base64.DEFAULT);
+
+        return performDecryption(keyStore, ivBytes, encryptedSecretBytes);
+    }
+
+    @NonNull
+    private String performDecryption(KeyStore keyStore, byte[] ivBytes, byte[] encryptedSecretBytes)
+        throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, InvalidAlgorithmParameterException, UnrecoverableEntryException, KeyStoreException, IllegalBlockSizeException, BadPaddingException, UnsupportedEncodingException {
+        final Cipher cipher = Cipher.getInstance(AES_MODE);
+        final GCMParameterSpec spec = new GCMParameterSpec(KEY_SIZE, ivBytes);
+        cipher.init(Cipher.DECRYPT_MODE, getSecretKey(ALIAS, keyStore), spec);
+
+        byte[] decryptedBytes = cipher.doFinal(encryptedSecretBytes);
+        return new String(decryptedBytes, 0, decryptedBytes.length, "UTF-8");
+    }
+
+    private SecretKey getSecretKey(final String alias, KeyStore keyStore) throws NoSuchAlgorithmException,
+        UnrecoverableEntryException, KeyStoreException {
+        return ((KeyStore.SecretKeyEntry) keyStore.getEntry(alias, null)).getSecretKey();
+    }
+
+    private String aesEncrypt(String alias, String secret)
+        throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException, UnsupportedEncodingException, KeyStoreException, JSONException {
+        SecretKey secretKey = generateAESSecretKey(alias);
+        return performEncryption(secretKey, secret.getBytes("UTF-8"));
+    }
+
+    private SecretKey generateAESSecretKey(String alias)
+        throws NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE);
+        keyGenerator.init(
+            new KeyGenParameterSpec.Builder(alias,
+                KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setRandomizedEncryptionRequired(true)
+                .build());
+        return keyGenerator.generateKey();
+    }
+
+    private String performEncryption(SecretKey secretKey, byte[] secretBytes)
+        throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException, JSONException, InvalidAlgorithmParameterException {
+
+        Cipher cipher = Cipher.getInstance(AES_MODE);
+
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey);
+
+        byte[] encryptedBytes = cipher.doFinal(secretBytes);
+        String base64Iv = Base64.encodeToString(cipher.getIV(), Base64.DEFAULT);
+        String base64Encrypted = Base64.encodeToString(encryptedBytes, Base64.DEFAULT);
+        return toJson(base64Iv, base64Encrypted);
+    }
+
+    private String toJson(String base64Iv, String base64EncyrptedSecret) throws JSONException {
+        JSONObject jsonObject = new JSONObject();
+        jsonObject.put(JSON_IV, base64Iv);
+        jsonObject.put(JSON_CIPHER, base64EncyrptedSecret);
+        return jsonObject.toString();
+    }
+
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/KeyStore.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/KeyStore.java
@@ -1,23 +1,22 @@
 package kin.sdk.core;
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import java.util.List;
+import kin.sdk.core.exception.CreateAccountException;
+import kin.sdk.core.exception.DeleteAccountException;
+import kin.sdk.core.exception.LoadAccountException;
 import org.stellar.sdk.KeyPair;
 
 interface KeyStore {
 
     @NonNull
-    List<Account> loadAccounts();
+    List<Account> loadAccounts() throws LoadAccountException;
 
-    void deleteAccount(int index, String passphrase);
+    void deleteAccount(int index) throws DeleteAccountException;
 
-    Account newAccount(String passphrase);
+    Account newAccount() throws CreateAccountException;
 
-    @Nullable
-    String exportAccount(@NonNull Account account, @NonNull String passphrase);
-
-    KeyPair decryptAccount(Account account, String passphrase);
+    KeyPair decryptAccount(Account account) throws CryptoException;
 
     void clearAllAccounts();
 }

--- a/kin-sdk-core/src/main/java/kin/sdk/core/KinAccount.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/KinAccount.java
@@ -15,13 +15,11 @@ public interface KinAccount {
     String getPublicAddress();
 
     /**
-     * Exports the keystore json file
+     * Deprecated, export will return null
      *
-     * @param passphrase the passphrase used to create the account
-     * @param newPassphrase the exported json will be encrypted using this new passphrase. The original keystore and
-     * passphrase will not change.
-     * @return String the json string
+     * @return null
      */
+    @Deprecated
     String exportKeyStore(String passphrase, String newPassphrase) throws PassphraseException, OperationFailedException;
 
     /**

--- a/kin-sdk-core/src/main/java/kin/sdk/core/KinAccount.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/KinAccount.java
@@ -15,14 +15,6 @@ public interface KinAccount {
     String getPublicAddress();
 
     /**
-     * Deprecated, export will return null
-     *
-     * @return null
-     */
-    @Deprecated
-    String exportKeyStore(String passphrase, String newPassphrase) throws PassphraseException, OperationFailedException;
-
-    /**
      * Create {@link Request} for signing and sending a transaction of the given amount in kin to the specified public
      * address
      * <p> See {@link KinAccount#sendTransactionSync(String, String, BigDecimal)} for possibles errors</p>

--- a/kin-sdk-core/src/main/java/kin/sdk/core/KinAccountImpl.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/KinAccountImpl.java
@@ -33,13 +33,6 @@ final class KinAccountImpl extends AbstractKinAccount {
     }
 
     @Override
-    public String exportKeyStore(String passphrase, String newPassphrase)
-        throws PassphraseException, OperationFailedException {
-        checkValidAccount();
-        return null;
-    }
-
-    @Override
     public TransactionId sendTransactionSync(String publicAddress, String passphrase, BigDecimal amount)
         throws OperationFailedException, PassphraseException {
         checkValidAccount();

--- a/kin-sdk-core/src/main/java/kin/sdk/core/KinAccountImpl.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/KinAccountImpl.java
@@ -29,8 +29,7 @@ final class KinAccountImpl extends AbstractKinAccount {
     public String exportKeyStore(String passphrase, String newPassphrase)
         throws PassphraseException, OperationFailedException {
         checkValidAccount();
-        KeyStore keyStore = clientWrapper.getKeyStore();
-        return keyStore.exportAccount(account, passphrase);
+        return null;
     }
 
     @Override

--- a/kin-sdk-core/src/main/java/kin/sdk/core/SharedPrefStore.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/SharedPrefStore.java
@@ -1,0 +1,33 @@
+package kin.sdk.core;
+
+
+import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+class SharedPrefStore implements Store {
+
+    private final SharedPreferences sharedPref;
+
+    SharedPrefStore(SharedPreferences sharedPref) {
+        this.sharedPref = sharedPref;
+    }
+
+    @Override
+    public void saveString(@NonNull String key, @NonNull String value) {
+        sharedPref.edit()
+            .putString(key, value)
+            .apply();
+    }
+
+    @Override
+    @Nullable
+    public String getString(@NonNull String key) {
+        return sharedPref.getString(key, null);
+    }
+
+    @Override
+    public void clear(@NonNull String key) {
+        sharedPref.edit().remove(key).apply();
+    }
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/Store.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/Store.java
@@ -1,0 +1,15 @@
+package kin.sdk.core;
+
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public interface Store {
+
+    void saveString(@NonNull String key, @NonNull String value);
+
+    @Nullable
+    String getString(@NonNull String key);
+
+    void clear(@NonNull String key);
+}

--- a/kin-sdk-core/src/main/java/kin/sdk/core/Store.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/Store.java
@@ -4,7 +4,7 @@ package kin.sdk.core;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-public interface Store {
+interface Store {
 
     void saveString(@NonNull String key, @NonNull String value);
 

--- a/kin-sdk-core/src/main/java/kin/sdk/core/TransactionSender.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/TransactionSender.java
@@ -52,10 +52,18 @@ class TransactionSender {
         checkParams(from, passphrase, publicAddress, amount);
         KeyPair addressee = generateAddresseeKeyPair(publicAddress);
         verifyAddresseeAccount(addressee);
-        KeyPair secretSeedKeyPair = keyStore.decryptAccount(from, passphrase);
+        KeyPair secretSeedKeyPair = decryptAccount(from, passphrase);
         AccountResponse sourceAccount = loadSourceAccount(secretSeedKeyPair);
         Transaction transaction = buildTransaction(secretSeedKeyPair, amount, addressee, sourceAccount);
         return sendTransaction(transaction);
+    }
+
+    private KeyPair decryptAccount(@NonNull Account from, @NonNull String passphrase) throws OperationFailedException {
+        try {
+            return keyStore.decryptAccount(from);
+        } catch (CryptoException e) {
+            throw new OperationFailedException(e);
+        }
     }
 
     private void checkParams(@NonNull Account from, @NonNull String passphrase, @NonNull String publicAddress,

--- a/kin-sdk-core/src/main/java/kin/sdk/core/exception/LoadAccountException.java
+++ b/kin-sdk-core/src/main/java/kin/sdk/core/exception/LoadAccountException.java
@@ -1,0 +1,9 @@
+package kin.sdk.core.exception;
+
+
+public class LoadAccountException extends Exception {
+
+    public LoadAccountException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/kin-sdk-core/src/test/java/kin/sdk/core/AccountActivatorTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/AccountActivatorTest.java
@@ -13,7 +13,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -64,7 +63,7 @@ public class AccountActivatorTest {
     private AccountActivator accountActivator;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
         mockServer();
@@ -83,8 +82,8 @@ public class AccountActivatorTest {
         server = new Server(url);
     }
 
-    private void mockKeyStoreResponse() {
-        when(mockKeyStore.decryptAccount(any(Account.class), anyString()))
+    private void mockKeyStoreResponse() throws CryptoException {
+        when(mockKeyStore.decryptAccount(any(Account.class)))
             .thenAnswer(
                 new Answer<Object>() {
                     @Override

--- a/kin-sdk-core/src/test/java/kin/sdk/core/EncryptorFactoryTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/EncryptorFactoryTest.java
@@ -1,0 +1,85 @@
+package kin.sdk.core;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import android.os.Build;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.util.ReflectionHelpers;
+
+@RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class EncryptorFactoryTest {
+
+    @ParameterizedRobolectricTestRunner.Parameters(name = "Version = {0}, Upgraded to = {1}, Expected Encryptor = {1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+            {16, 0, EncryptorImplV16.class},
+            {17, 0, EncryptorImplV16.class},
+            {18, 0, EncryptorImplV18.class},
+            {19, 0, EncryptorImplV18.class},
+            {20, 0, EncryptorImplV18.class},
+            {21, 0, EncryptorImplV18.class},
+            {22, 0, EncryptorImplV18.class},
+            {23, 0, EncryptorImplV23.class},
+            {24, 0, EncryptorImplV23.class},
+            {25, 0, EncryptorImplV23.class},
+            {26, 0, EncryptorImplV23.class},
+            {27, 0, EncryptorImplV23.class},
+            {28, 0, EncryptorImplV23.class},
+
+            {16, 17, EncryptorImplV16.class},
+            {17, 26, EncryptorImplV16.class},
+            {16, 18, EncryptorImplV16.class},
+            {16, 23, EncryptorImplV16.class},
+
+            {18, 19, EncryptorImplV18.class},
+            {18, 23, EncryptorImplV18.class},
+            {19, 26, EncryptorImplV18.class},
+            {20, 26, EncryptorImplV18.class},
+            {22, 23, EncryptorImplV18.class},
+
+            {23, 24, EncryptorImplV23.class},
+            {24, 25, EncryptorImplV23.class},
+            {25, 26, EncryptorImplV23.class},
+        });
+    }
+
+    private int upgradedVersion;
+    private Class<?> expectedEncryptorClass;
+
+    public EncryptorFactoryTest(int androidVersion, int upgradedVersion, Class<?> expectedEncryptorClass) {
+        setAndroidSDKVersion(androidVersion);
+        this.expectedEncryptorClass = expectedEncryptorClass;
+        this.upgradedVersion = upgradedVersion;
+    }
+
+    @Test
+    public void create() throws Exception {
+        Store store = new FakeStore();
+        if (upgradedVersion != 0) {
+            simulateUpgradeOfAndroidVersion(store);
+        }
+        Encryptor encryptor = EncryptorFactory.create(RuntimeEnvironment.application, store);
+
+        assertThat(encryptor, is(instanceOf(expectedEncryptorClass)));
+    }
+
+    private void simulateUpgradeOfAndroidVersion(Store store) {
+        //create should save the OS version Encryptor was created with
+        EncryptorFactory.create(RuntimeEnvironment.application, store);
+        //now change the SDK (simulate upgrade)
+        setAndroidSDKVersion(upgradedVersion);
+    }
+
+    private void setAndroidSDKVersion(int version) {
+        ReflectionHelpers.setStaticField(Build.VERSION.class, "SDK_INT", version);
+    }
+}

--- a/kin-sdk-core/src/test/java/kin/sdk/core/EncryptorImplV16Test.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/EncryptorImplV16Test.java
@@ -1,0 +1,33 @@
+package kin.sdk.core;
+
+import static junit.framework.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class EncryptorImplV16Test {
+
+    private Encryptor cryptor;
+
+    @Before
+    public void setup() {
+        cryptor = new EncryptorImplV16();
+    }
+
+    @Test
+    public void encryptThenDecrypt_Success() throws Exception {
+        String secretSeed = "SDL34EFTWFPIVJLUYSCVZJFYPYLIGFHDYG5VKOVBQYLU6H4OWRPETCAE";
+        String encryptedSecret = cryptor.encrypt(secretSeed);
+        String actualDecryptedSeed = cryptor.decrypt(encryptedSecret);
+        assertEquals(secretSeed, actualDecryptedSeed);
+    }
+
+    @Test
+    public void decrypt_NotEqualsToSource() throws Exception {
+        String secret = "SCJFLXKUY6VQT2LYSP6XDP23WNEP5OITSC3LZEJUJO7GFZM7QLDF2BCN";
+        String encryptedSecret = cryptor.encrypt(secret);
+        //V16 encryptor is no-op that do not encrypt
+        assertEquals(encryptedSecret, secret);
+    }
+
+}

--- a/kin-sdk-core/src/test/java/kin/sdk/core/FakeKeyStore.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/FakeKeyStore.java
@@ -2,7 +2,6 @@ package kin.sdk.core;
 
 
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import org.stellar.sdk.KeyPair;
@@ -23,7 +22,7 @@ class FakeKeyStore implements KeyStore {
     }
 
     @Override
-    public void deleteAccount(int index, String passphrase) {
+    public void deleteAccount(int index) {
         accounts.remove(index);
     }
 
@@ -34,21 +33,16 @@ class FakeKeyStore implements KeyStore {
     }
 
     @Override
-    public Account newAccount(String passphrase) {
+    public Account newAccount() {
+
         KeyPair keyPair = KeyPair.random();
         Account account = new Account(new String(keyPair.getSecretSeed()), keyPair.getAccountId());
         accounts.add(account);
         return account;
     }
 
-    @Nullable
     @Override
-    public String exportAccount(@NonNull Account account, @NonNull String passphrase) {
-        return null;
-    }
-
-    @Override
-    public KeyPair decryptAccount(Account account, String passphrase) {
+    public KeyPair decryptAccount(Account account) {
         return KeyPair.fromSecretSeed(account.getEncryptedSeed());
     }
 

--- a/kin-sdk-core/src/test/java/kin/sdk/core/FakeStore.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/FakeStore.java
@@ -1,0 +1,30 @@
+package kin.sdk.core;
+
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import java.util.HashMap;
+
+class FakeStore implements Store {
+
+    private HashMap<String, String> map = new HashMap<>();
+
+    FakeStore() {
+    }
+
+    @Override
+    public void saveString(@NonNull String key, @NonNull String value) {
+        map.put(key, value);
+    }
+
+    @Nullable
+    @Override
+    public String getString(@NonNull String key) {
+        return map.get(key);
+    }
+
+    @Override
+    public void clear(@NonNull String key) {
+        map.remove(key);
+    }
+}

--- a/kin-sdk-core/src/test/java/kin/sdk/core/KeyStoreImplTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/KeyStoreImplTest.java
@@ -1,0 +1,173 @@
+package kin.sdk.core;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.core.Is.isA;
+import static org.junit.Assert.assertNotEquals;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import java.util.HashMap;
+import java.util.List;
+import kin.sdk.core.exception.CreateAccountException;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.stellar.sdk.KeyPair;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 23, manifest = Config.NONE)
+public class KeyStoreImplTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+    private KeyStoreImpl keyStore;
+
+    private static class FakeEncryptor implements Encryptor {
+
+        @Override
+        public String encrypt(String secret) throws CryptoException {
+            return "{FAKE}" + secret + "{FAKE}";
+        }
+
+        @Override
+        public String decrypt(String encryptedSecret) throws CryptoException {
+            return encryptedSecret.replace("{FAKE}", "");
+        }
+    }
+
+    private static class ExceptionThrowerEncryptor implements Encryptor {
+
+        @Override
+        public String encrypt(String secret) throws CryptoException {
+            throw new CryptoException(new Exception("Some bad things happened"));
+        }
+
+        @Override
+        public String decrypt(String encryptedSecret) throws CryptoException {
+            throw new CryptoException(new Exception("Some bad things happened"));
+        }
+    }
+
+    private static class ExceptionThrowerStore implements Store {
+
+        HashMap<String, String> map = new HashMap<>();
+
+        @Override
+        public void saveString(@NonNull String key, @NonNull String value) {
+            map.put(key, value);
+        }
+
+        @Nullable
+        @Override
+        public String getString(@NonNull String key) {
+            return "NotJsonString";
+        }
+
+        @Override
+        public void clear(@NonNull String key) {
+            map.remove(key);
+        }
+    }
+
+    private static class FakeStore implements Store {
+
+        HashMap<String, String> map = new HashMap<>();
+
+        @Override
+        public void saveString(@NonNull String key, @NonNull String value) {
+            map.put(key, value);
+        }
+
+        @Nullable
+        @Override
+        public String getString(@NonNull String key) {
+            return map.get(key);
+        }
+
+        @Override
+        public void clear(@NonNull String key) {
+            map.remove(key);
+        }
+    }
+
+    @Before
+    public void setup() {
+        keyStore = new KeyStoreImpl(new FakeStore(), new FakeEncryptor());
+    }
+
+    @Test
+    public void newAccount() throws Exception {
+        Account account = keyStore.newAccount();
+        KeyPair keyPair = keyStore.decryptAccount(account);
+        assertEquals(account.getAccountId(), keyPair.getAccountId());
+        assertNotEquals(account.getEncryptedSeed(), String.valueOf(keyPair.getSecretSeed()));
+    }
+
+    @Test
+    public void newAccount_CryptoException_CreateAccountException() throws Exception {
+        keyStore = new KeyStoreImpl(new FakeStore(), new ExceptionThrowerEncryptor());
+
+        expectedEx.expect(CreateAccountException.class);
+        expectedEx.expectCause(isA(CryptoException.class));
+        keyStore.newAccount();
+    }
+
+    @Test
+    public void newAccount_JsonException_CreateAccountException() throws Exception {
+        keyStore = new KeyStoreImpl(new ExceptionThrowerStore(), new FakeEncryptor());
+
+        expectedEx.expect(CreateAccountException.class);
+        expectedEx.expectCause(isA(JSONException.class));
+        keyStore.newAccount();
+    }
+
+    @Test
+    public void loadAccounts() throws Exception {
+        Account account1 = keyStore.newAccount();
+        Account account2 = keyStore.newAccount();
+        List<Account> accounts = keyStore.loadAccounts();
+        Account actualAccount1 = accounts.get(0);
+        Account actualAccount2 = accounts.get(1);
+        assertEquals(account1.getEncryptedSeed(), actualAccount1.getEncryptedSeed());
+        assertEquals(account1.getAccountId(), actualAccount1.getAccountId());
+        assertEquals(account2.getEncryptedSeed(), actualAccount2.getEncryptedSeed());
+        assertEquals(account2.getAccountId(), actualAccount2.getAccountId());
+    }
+
+    @Test
+    public void loadAccounts_JsonException_LoadAccountException() throws Exception {
+        keyStore.newAccount();
+        keyStore.newAccount();
+        expectedEx.expect(CreateAccountException.class);
+        expectedEx.expectCause(isA(JSONException.class));
+        keyStore.loadAccounts();
+    }
+
+    @Test
+    public void deleteAccount() throws Exception {
+        Account account1 = keyStore.newAccount();
+        keyStore.newAccount();
+        keyStore.deleteAccount(1);
+
+        List<Account> accounts = keyStore.loadAccounts();
+        assertEquals(1, accounts.size());
+        assertEquals(account1.getAccountId(), accounts.get(0).getAccountId());
+        assertEquals(account1.getEncryptedSeed(), accounts.get(0).getEncryptedSeed());
+    }
+
+    @Test
+    public void clearAllAccounts() throws Exception {
+        keyStore.newAccount();
+        keyStore.newAccount();
+        keyStore.clearAllAccounts();
+        assertTrue(keyStore.loadAccounts().isEmpty());
+    }
+
+}

--- a/kin-sdk-core/src/test/java/kin/sdk/core/TransactionSenderTest.java
+++ b/kin-sdk-core/src/test/java/kin/sdk/core/TransactionSenderTest.java
@@ -14,7 +14,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -70,7 +69,7 @@ public class TransactionSenderTest {
     private Account account;
 
     @Before
-    public void setup() throws IOException {
+    public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
 
         mockServer();
@@ -89,8 +88,8 @@ public class TransactionSenderTest {
         server = new Server(url);
     }
 
-    private void mockKeyStoreResponse() {
-        when(mockKeyStore.decryptAccount(any(Account.class), anyString()))
+    private void mockKeyStoreResponse() throws CryptoException {
+        when(mockKeyStore.decryptAccount(any(Account.class)))
             .thenAnswer(
                 new Answer<Object>() {
                     @Override

--- a/sample/src/main/java/kin/sdk/core/sample/CreateWalletActivity.java
+++ b/sample/src/main/java/kin/sdk/core/sample/CreateWalletActivity.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import kin.sdk.core.KinClient;
+import kin.sdk.core.exception.CreateAccountException;
+import kin.sdk.core.sample.kin.sdk.core.sample.dialog.KinAlertDialog;
 
 /**
  * This activity is displayed only if there is no existing account stored on device for the given network
@@ -34,9 +36,13 @@ public class CreateWalletActivity extends BaseActivity {
     }
 
     private void createAccount() {
-        final KinClient kinClient = getKinClient();
-        kinClient.createAccount(getPassphrase());
-        startActivity(WalletActivity.getIntent(this));
+        try {
+            final KinClient kinClient = getKinClient();
+            kinClient.createAccount(getPassphrase());
+            startActivity(WalletActivity.getIntent(this));
+        } catch (CreateAccountException e) {
+            KinAlertDialog.createErrorDialog(this, e.getMessage()).show();
+        }
     }
 
     @Override


### PR DESCRIPTION
* add secure keystore implementation
* use Android KeyStore with RSA for Android 18-22, AES for 23+,
 and non-secure for 16-17
* write tests for the different KeyStore implementations, tests should
 run on the proper platform, o.w. tests will be skipped