### PR TITLE
fix android tests not reporting failure to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,5 @@ script:
   - ./gradlew :kin-core:test
   - ./gradlew kin-core:assembleDebugAndroidTest
   - adb install -r ./kin-core/build/outputs/apk/androidTest/debug/kin-core-debug-androidTest.apk
-  #filter out @LargeTest annotated tests, these tests reach network and are flaky
-  - adb shell am instrument -w -e notAnnotation android.support.test.filters.LargeTest  kin.core.test/android.support.test.runner.AndroidJUnitRunner
+  - ./run_android_test_ci.sh
 

--- a/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
@@ -343,6 +343,7 @@ public class KinAccountIntegrationTest {
 
     @Test
     public void getPublicAddress_DeletedAccount_EmptyPublicAddress() throws Exception {
+        fail("test failure in travis!!");
         KinAccount kinAccount = kinClient.addAccount(PASSPHRASE);
         kinClient.deleteAccount(0, PASSPHRASE);
         assertNull(kinAccount.getPublicAddress());

--- a/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
@@ -343,7 +343,6 @@ public class KinAccountIntegrationTest {
 
     @Test
     public void getPublicAddress_DeletedAccount_EmptyPublicAddress() throws Exception {
-        fail("test failure in travis!!");
         KinAccount kinAccount = kinClient.addAccount(PASSPHRASE);
         kinClient.deleteAccount(0, PASSPHRASE);
         assertNull(kinAccount.getPublicAddress());

--- a/run_android_test_ci.sh
+++ b/run_android_test_ci.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+#use `am instrument` to filter out @LargeTest annotated tests in CI, these tests access the network (test net) and are flaky
+instrumentationResult=$(adb shell 'am instrument -w -e notAnnotation android.support.test.filters.LargeTest  kin.core.test/android.support.test.runner.AndroidJUnitRunner')
+printf "$instrumentationResult\n"
+
+if [[ $instrumentationResult = *"FAILURES!!!"* ]]; then
+  exit 1
+fi


### PR DESCRIPTION
adb shell has a known issue that it doesn't report back exit status code,
besides that 'am instrument' as well not seems to report error status code,
it returns 0 even for failed tests, so trying to capture status code 'echo $?'
inside shell will result in success exit code (0) always.
instead use a hacky way of searching for failure strings in am instrument
output.