### PR TITLE
Code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,6 @@ script:
   - ./gradlew :sample:assembleDebug
   #skip large network related test in KinAccountIntegrationTest class
   - ./gradlew jacocoTestReport  -Pandroid.testInstrumentationRunnerArguments.notClass=kin.core.KinAccountIntegrationTest
+
+  after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,5 @@ before_script:
 
 script:
   - ./gradlew :sample:assembleDebug
-  - ./gradlew :kin-core:test
-  - ./gradlew kin-core:assembleDebugAndroidTest
-  - adb install -r ./kin-core/build/outputs/apk/androidTest/debug/kin-core-debug-androidTest.apk
-  - ./run_android_test_ci.sh
-
+  #skip large network related test in KinAccountIntegrationTest class
+  - ./gradlew jacocoTestReport  -Pandroid.testInstrumentationRunnerArguments.notClass=kin.core.KinAccountIntegrationTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ script:
   #skip large network related test in KinAccountIntegrationTest class
   - ./gradlew jacocoTestReport  -Pandroid.testInstrumentationRunnerArguments.notClass=kin.core.KinAccountIntegrationTest
 
-  after_success:
-    - bash <(curl -s https://codecov.io/bash)
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'org.jacoco:org.jacoco.core:0.8.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,13 +6,13 @@ ext {
 }
 
 buildscript {
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
-        classpath 'org.jacoco:org.jacoco.core:0.8.0'
+        classpath "com.android.tools.build:gradle:3.0.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,8 @@ buildscript {
     }
     dependencies {
         classpath "com.android.tools.build:gradle:3.0.1"
+        classpath 'org.jacoco:org.jacoco.core:0.8.1'
+
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,6 +10,7 @@ ext {
     robolectricVersion = '3.6.1'
     hamcrestVersion = '1.3'
     gsonVersion = '2.4'
+    jacocoVersion = '0.8.0'
 
     //Packages
     supportPackage = 'com.android.support'

--- a/kin-core/build.gradle
+++ b/kin-core/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath "org.jacoco:org.jacoco.core:${jacocoVersion}"
+    }
+}
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 
@@ -65,7 +74,7 @@ artifacts {
 
 //jacoco unified code coverage
 jacoco {
-    toolVersion = '0.8.0'
+    toolVersion = jacocoVersion
 }
 
 tasks.withType(Test) {

--- a/kin-core/build.gradle
+++ b/kin-core/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'jacoco'
 
 // maven plugin and group definition
 // needed for jitpack support
@@ -16,6 +17,18 @@ android {
         versionName "1.0"
         consumerProguardFiles 'proguard-rules.pro'
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        debug {
+            testCoverageEnabled true
+        }
+    }
+
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
     }
 }
 
@@ -48,4 +61,31 @@ task sourcesJar(type: Jar) {
 }
 artifacts {
     archives sourcesJar
+}
+
+//jacoco unified code coverage
+jacoco {
+    toolVersion = '0.8.0'
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        html.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/classes/debug", excludes: fileFilter)
+    def mainSrc = "$project.projectDir/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec', 'outputs/code-coverage/connected/*coverage.ec'
+    ])
 }

--- a/kin-core/build.gradle
+++ b/kin-core/build.gradle
@@ -1,12 +1,3 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath "org.jacoco:org.jacoco.core:${jacocoVersion}"
-    }
-}
 apply plugin: 'com.android.library'
 apply plugin: 'jacoco'
 
@@ -79,7 +70,7 @@ artifacts {
 
 //jacoco unified code coverage
 jacoco {
-    toolVersion = jacocoVersion
+    toolVersion = '0.8.1'
 }
 
 tasks.withType(Test) {

--- a/kin-core/src/androidTest/java/kin/core/FakeKinIssuer.java
+++ b/kin-core/src/androidTest/java/kin/core/FakeKinIssuer.java
@@ -2,10 +2,11 @@ package kin.core;
 
 
 import static junit.framework.Assert.assertTrue;
+import static kin.core.IntegConsts.TEST_NETWORK_URL;
+import static kin.core.IntegConsts.URL_CREATE_ACCOUNT;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.stellar.sdk.Asset;
@@ -23,11 +24,6 @@ import org.stellar.sdk.responses.SubmitTransactionResponse;
 class FakeKinIssuer {
 
     private static final int TIMEOUT_SEC = 20;
-    private static final String TEST_NETWORK_URL = "https://horizon-testnet.stellar.org";
-    private static final String TEST_NETWORK_SCHEME = "https";
-    private static final String TEST_NETWORK_HOST = "horizon-testnet.stellar.org";
-    private static final String TEST_NETWORK_PATH_SEGMENT = "friendbot";
-    private static final String TEST_NETWORK_QUERY_PARAM = "addr";
 
     private final Server server;
     private final KeyPair issuerKeyPair;
@@ -45,15 +41,9 @@ class FakeKinIssuer {
     }
 
     private void createAndFundWithLumens(String accountId) throws IOException {
-        HttpUrl url = new HttpUrl.Builder()
-            .scheme(TEST_NETWORK_SCHEME)
-            .host(TEST_NETWORK_HOST)
-            .addPathSegment(TEST_NETWORK_PATH_SEGMENT)
-            .addQueryParameter(TEST_NETWORK_QUERY_PARAM, accountId)
-            .build();
         OkHttpClient client = new OkHttpClient();
         okhttp3.Request request = new okhttp3.Request.Builder()
-            .url(url).build();
+            .url(URL_CREATE_ACCOUNT + accountId).build();
         Response response = client.newCall(request).execute();
         assertTrue(response != null && response.body() != null && response.code() == 200);
     }

--- a/kin-core/src/androidTest/java/kin/core/IntegConsts.java
+++ b/kin-core/src/androidTest/java/kin/core/IntegConsts.java
@@ -1,0 +1,9 @@
+package kin.core;
+
+
+final class IntegConsts {
+
+    static final String TEST_NETWORK_URL = "https://horizon-kik.kininfrastructure.com";
+    static final String TEST_NETWORK_ID = "private testnet";
+    static final String URL_CREATE_ACCOUNT = "http://friendbot-kik.kininfrastructure.com/?addr=";
+}

--- a/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
@@ -275,9 +275,19 @@ public class KinAccountIntegrationTest {
         kinAccountReceiver.activateSync();
         fakeKinIssuer.fundWithKin(kinAccountSender.getPublicAddress(), "100");
 
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch fundingLatch = new CountDownLatch(1);
+        kinAccountSender.blockchainEvents().addPaymentListener(new EventListener<PaymentInfo>() {
+            @Override
+            public void onEvent(PaymentInfo data) {
+                fundingLatch.countDown();
+            }
+        });
+        fundingLatch.await(10, TimeUnit.SECONDS);
+
         final List<PaymentInfo> actualResults = new ArrayList<>();
         KinAccount accountToListen = sender ? kinAccountSender : kinAccountReceiver;
+
+        final CountDownLatch latch = new CountDownLatch(1);
         accountToListen.blockchainEvents().addPaymentListener(new EventListener<PaymentInfo>() {
             @Override
             public void onEvent(PaymentInfo data) {

--- a/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinAccountIntegrationTest.java
@@ -2,6 +2,8 @@ package kin.core;
 
 
 import static junit.framework.Assert.fail;
+import static kin.core.IntegConsts.TEST_NETWORK_ID;
+import static kin.core.IntegConsts.TEST_NETWORK_URL;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -32,7 +34,6 @@ import org.stellar.sdk.responses.TransactionResponse;
 @SuppressWarnings({"deprecation", "ConstantConditions"})
 public class KinAccountIntegrationTest {
 
-    private static final String TEST_NETWORK_URL = "https://horizon-testnet.stellar.org";
     private static FakeKinIssuer fakeKinIssuer;
     private KinClient kinClient;
 
@@ -47,7 +48,7 @@ public class KinAccountIntegrationTest {
     private class TestServiceProvider extends ServiceProvider {
 
         TestServiceProvider() {
-            super(TEST_NETWORK_URL, NETWORK_ID_TEST);
+            super(TEST_NETWORK_URL, TEST_NETWORK_ID);
         }
 
         @Override

--- a/kin-core/src/androidTest/java/kin/core/KinClientIntegrationTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinClientIntegrationTest.java
@@ -6,6 +6,8 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
+import static kin.core.IntegConsts.TEST_NETWORK_ID;
+import static kin.core.IntegConsts.TEST_NETWORK_URL;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,7 +23,6 @@ import org.junit.rules.ExpectedException;
 @SuppressWarnings("deprecation")
 public class KinClientIntegrationTest {
 
-    private static final String TEST_NETWORK_URL = "https://horizon-testnet.stellar.org";
     private ServiceProvider serviceProvider;
     private KinClient kinClient;
 
@@ -30,7 +31,7 @@ public class KinClientIntegrationTest {
 
     @Before
     public void setup() {
-        serviceProvider = new ServiceProvider(TEST_NETWORK_URL, ServiceProvider.NETWORK_ID_TEST);
+        serviceProvider = new ServiceProvider(TEST_NETWORK_URL, TEST_NETWORK_ID);
         kinClient = new KinClient(InstrumentationRegistry.getTargetContext(), serviceProvider);
         kinClient.clearAllAccounts();
     }

--- a/kin-core/src/androidTest/java/kin/core/RequestTest.java
+++ b/kin-core/src/androidTest/java/kin/core/RequestTest.java
@@ -20,8 +20,8 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class RequestTest {
 
-    private static final int TASK_DURATION_MILLIS = 10;
-    private static final int TIMEOUT_DURATION_MILLIS = 100;
+    private static final int TASK_DURATION_MILLIS = 100;
+    private static final int TIMEOUT_DURATION_MILLIS = 500;
 
     public interface Consumer<T> {
 

--- a/kin-core/src/test/java/kin/core/BlockchainEventsTest.java
+++ b/kin-core/src/test/java/kin/core/BlockchainEventsTest.java
@@ -259,6 +259,7 @@ public class BlockchainEventsTest {
 
         assertThat(balance1, notNullValue());
         assertThat(balance2, notNullValue());
+        //expected balances values are the ones encoded at transactions responses jsons (see enqueueTransactionsResponses)
         assertThat(balance1.value(), equalTo(new BigDecimal("5387.216")));
         assertThat(balance2.value(), equalTo(new BigDecimal("5239.89036")));
     }

--- a/run_android_test_ci.sh
+++ b/run_android_test_ci.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-#use `am instrument` to filter out @LargeTest annotated tests in CI, these tests access the network (test net) and are flaky
-instrumentationResult=$(adb shell 'am instrument -w -e notAnnotation android.support.test.filters.LargeTest  kin.core.test/android.support.test.runner.AndroidJUnitRunner')
-printf "$instrumentationResult\n"
-
-if [[ $instrumentationResult = *"FAILURES!!!"* ]]; then
-  exit 1
-fi


### PR DESCRIPTION
unified report for unit test + instrumentation test + codecov report in github
(KinAccountIntegrationTest do not run on travis CI as they access the network and are flaky)
* add jacoco and gradle task for generating a unified report
* travis.yml - am instrument is not needed, parameter added to gradlew,
jacocoTestReport will run both unit test and android test, no need to run each separately
* run tests against kin private testnet
* move all consts to one class IntegConsts
* increase duration in RequestTest to prevent flakiness
* integrate codecov