### PR TITLE
Backup enable migration fix

### DIFF
--- a/kin-core/src/main/java/kin/core/KeyStoreImpl.java
+++ b/kin-core/src/main/java/kin/core/KeyStoreImpl.java
@@ -55,7 +55,7 @@ class KeyStoreImpl implements KeyStore {
                 return json.getJSONArray(JSON_KEY_ACCOUNTS_ARRAY);
             }
         } else {
-            store.saveString(STORE_KEY_ACCOUNTS, "");
+            store.clear(STORE_KEY_ACCOUNTS);
             store.saveString(VERSION_KEY, ENCRYPTION_VERSION_NAME);
         }
         return null;

--- a/kin-core/src/main/java/kin/core/KeyStoreImpl.java
+++ b/kin-core/src/main/java/kin/core/KeyStoreImpl.java
@@ -55,6 +55,7 @@ class KeyStoreImpl implements KeyStore {
                 return json.getJSONArray(JSON_KEY_ACCOUNTS_ARRAY);
             }
         } else {
+            store.saveString(STORE_KEY_ACCOUNTS, "");
             store.saveString(VERSION_KEY, ENCRYPTION_VERSION_NAME);
         }
         return null;

--- a/kin-core/src/main/java/kin/core/KeyStoreImpl.java
+++ b/kin-core/src/main/java/kin/core/KeyStoreImpl.java
@@ -14,11 +14,11 @@ import org.stellar.sdk.KeyPair;
 class KeyStoreImpl implements KeyStore {
 
     static final String ENCRYPTION_VERSION_NAME = "none";
-    private static final String STORE_KEY_ACCOUNTS = "accounts";
+    static final String STORE_KEY_ACCOUNTS = "accounts";
+    static final String VERSION_KEY = "encryptor_ver";
     private static final String JSON_KEY_ACCOUNTS_ARRAY = "accounts";
     private static final String JSON_KEY_PUBLIC_KEY = "public_key";
     private static final String JSON_KEY_ENCRYPTED_SEED = "seed";
-    private static final String VERSION_KEY = "encryptor_ver";
 
     private final Store store;
 

--- a/kin-core/src/test/java/kin/core/KeyStoreImplTest.java
+++ b/kin-core/src/test/java/kin/core/KeyStoreImplTest.java
@@ -3,7 +3,10 @@ package kin.core;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.isA;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -49,6 +52,19 @@ public class KeyStoreImplTest {
         expectedEx.expect(CreateAccountException.class);
         expectedEx.expectCause(isA(JSONException.class));
         keyStore.newAccount();
+    }
+
+    @Test
+    public void loadAccounts_OldVersionData_DropOldData() throws Exception {
+        FakeStore fakeStore = new FakeStore();
+        fakeStore.saveString(KeyStoreImpl.VERSION_KEY, "some_version");
+        fakeStore.saveString(KeyStoreImpl.STORE_KEY_ACCOUNTS,
+            "{&quot;accounts&quot;:[{&quot;seed&quot;:&quot;{\\&quot;iv\\&quot;:\\&quot;nVGsoEHgjW4xw2gx\\\\n\\&quot;,\\&quot;cipher\\&quot;:\\&quot;kEC64vaQu\\\\\\/erpFvvnrY+sWm\\\\\\/o4GjmjPfgG31zQTwvp0taxo\\\\\\/04PoaisjfEQxrydRwBGFvG\\\\\\/nG345\\\\ntXMn+x2H0jnaPWWCznPA\\\\n\\&quot;}&quot;,&quot;public_key&quot;:&quot;GBYPGYWPWHWSVTQGTUCH2IICIP2PRLN3QYSUX5NOHHMNDQW26A4WK2IK&quot;}]}");
+        KeyStoreImpl keyStore = new KeyStoreImpl(fakeStore);
+
+        keyStore.loadAccounts();
+        assertThat(fakeStore.getString(KeyStoreImpl.VERSION_KEY), equalTo(KeyStoreImpl.ENCRYPTION_VERSION_NAME));
+        assertThat(fakeStore.getString(KeyStoreImpl.STORE_KEY_ACCOUNTS), nullValue());
     }
 
     @Test


### PR DESCRIPTION
fix a problem when migrating from a former version with encrypted data to newer version (backup supported) without encrypted data.

* old data wasn't really deleted, and caused kin-core to have 2 data sets, one old (encrypted) and the new one, when loading `KinClient` for the second time, an exception will be raised as encrypted data cannot be loaded.