### PR TITLE
Calculate transaction hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,10 @@ The following code will transfer 20 KIN to the recipient account "GDIRGGTBE3H4CU
 String toAddress = "GDIRGGTBE3H4CUIHNIFZGUECGFQ5MBGIZTPWGUHPIEVOOHFHSCAGMEHO";
 BigDecimal amountInKin = new BigDecimal("20");
 
-// build the transaction
+// Build the transaction and get a Request<Transaction> object.
 buildTransactionRequest = account.buildTransaction(toAddress, amountInKin);
+// Actually run the build transaction code in a background thread and get 
+// notify of success/failure methods which runs on the main thread
 buildTransactionRequest.run(new ResultCallback<TransactionId>() {
 
     @Override
@@ -194,9 +196,10 @@ buildTransactionRequest.run(new ResultCallback<TransactionId>() {
         // So when the network is back we can check what is the status of this transaction.
         Log.d("example", "The transaction id before sending: " + transaction.getId().id());
 
-        // Send the transaction
+        // Create the send transaction request
         sendTransactionRequest = account.sendTransaction(transaction);
-        transactionRequest.run(new ResultCallback<TransactionId>() {
+        // Actually send the transaction in a background thread.
+        sendTransactionRequest.run(new ResultCallback<TransactionId>() {
 
             @Override
             public void onResult(TransactionId id) {
@@ -226,21 +229,16 @@ the memo can contain a utf-8 string up to 21 bytes in length. A typical usage is
 
 ```java
 String memo = "arbitrary data";
-// build the transaction
+
 buildTransactionRequest = account.buildTransaction(toAddress, amountInKin, memo);
-buildTransactionRequest.run(new ResultCallback<TransactionId>()
-
-
-transactionRequest = account.sendTransaction(toAddress, amountInKin, memo);
-transactionRequest.run(new ResultCallback<TransactionId>() {
+buildTransactionRequest.run(new ResultCallback<TransactionId>() {
 
     @Override
     public void onResult(Transaction transaction) {
         Log.d("example", "The transaction id before sending: " + transaction.getId.().id());
 
-        // Send the transaction
         sendTransactionRequest = account.sendTransaction(transaction);
-        transactionRequest.run(new ResultCallback<TransactionId>() {
+        sendTransactionRequest.run(new ResultCallback<TransactionId>() {
 
             @Override
             public void onResult(TransactionId id) {
@@ -252,7 +250,6 @@ transactionRequest.run(new ResultCallback<TransactionId>() {
                 e.printStackTrace();
             }
         });
-
     }
 
     @Override

--- a/README.md
+++ b/README.md
@@ -181,19 +181,42 @@ The following code will transfer 20 KIN to the recipient account "GDIRGGTBE3H4CU
 String toAddress = "GDIRGGTBE3H4CUIHNIFZGUECGFQ5MBGIZTPWGUHPIEVOOHFHSCAGMEHO";
 BigDecimal amountInKin = new BigDecimal("20");
 
-transactionRequest = account.sendTransaction(toAddress, amountInKin);
-transactionRequest.run(new ResultCallback<TransactionId>() {
+// build the transaction
+buildTransactionRequest = account.buildTransaction(toAddress, amountInKin);
+buildTransactionRequest.run(new ResultCallback<TransactionId>() {
 
     @Override
-        public void onResult(TransactionId result) {
-            Log.d("example", "The transaction id: " + result.toString());
-        }
+    public void onResult(Transaction transaction) {
+        // Here we already got a Transaction object before sending the transaction. This means 
+        // that we can, for example, send the transaction id to our servers or save it locally  
+        // in order to use it later. For example if we lose network just after sending 
+        // the transaction then we will not know what happened with this transaction. 
+        // So when the network is back we can check what is the status of this transaction.
+        Log.d("example", "The transaction id before sending: " + transaction.getId().id());
 
-        @Override
-        public void onError(Exception e) {
-            e.printStackTrace();
-        }
+        // Send the transaction
+        sendTransactionRequest = account.sendTransaction(transaction);
+        transactionRequest.run(new ResultCallback<TransactionId>() {
+
+            @Override
+            public void onResult(TransactionId id) {
+                Log.d("example", "The transaction id: " + id);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+    }
+
+    @Override
+    public void onError(Exception e) {
+        e.printStackTrace();
+    }
 });
+
 ```
 
 #### Memo
@@ -203,18 +226,40 @@ the memo can contain a utf-8 string up to 21 bytes in length. A typical usage is
 
 ```java
 String memo = "arbitrary data";
+// build the transaction
+buildTransactionRequest = account.buildTransaction(toAddress, amountInKin, memo);
+buildTransactionRequest.run(new ResultCallback<TransactionId>()
+
+
 transactionRequest = account.sendTransaction(toAddress, amountInKin, memo);
 transactionRequest.run(new ResultCallback<TransactionId>() {
 
     @Override
-        public void onResult(TransactionId result) {
-            Log.d("example", "The transaction id: " + result.toString());
-        }
+    public void onResult(Transaction transaction) {
+        Log.d("example", "The transaction id before sending: " + transaction.getId.().id());
 
-        @Override
-        public void onError(Exception e) {
-            e.printStackTrace();
-        }
+        // Send the transaction
+        sendTransactionRequest = account.sendTransaction(transaction);
+        transactionRequest.run(new ResultCallback<TransactionId>() {
+
+            @Override
+            public void onResult(TransactionId id) {
+                Log.d("example", "The transaction id: " + id);
+            }
+
+            @Override
+            public void onError(Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+    }
+
+    @Override
+    public void onError(Exception e) {
+        e.printStackTrace();
+    }
+    
 });
 ```
 
@@ -280,7 +325,10 @@ try {
 }
 
 try {
-    TransactionId transactionId = account.sendTransactionSync(toAddress, amountInKin);
+    // build the transaction
+    Transaction transaction = account.buildTransactionSync(toAddress, amountInKin)
+    // send the transaction
+    TransactionId transactionId = account.sendTransactionSync(transaction);
 } catch (OperationFailedException e){
     // something else went wrong - check the exception message
 }

--- a/kin-core/src/androidTest/java/kin/core/KinAccountTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinAccountTest.java
@@ -4,7 +4,6 @@ package kin.core;
 import static junit.framework.Assert.assertNull;
 
 import android.support.test.InstrumentationRegistry;
-import java.io.IOException;
 import java.math.BigDecimal;
 import kin.core.exception.AccountDeletedException;
 import org.junit.After;
@@ -59,8 +58,9 @@ public class KinAccountTest {
     public void sendTransactionSync_DeletedAccount_AccountDeletedException() throws Exception {
         KinAccount kinAccount = kinClient.addAccount();
         kinClient.deleteAccount(0);
-        kinAccount.sendTransactionSync("GBA2XHZRUAHEL4DZX7XNHR7HLBAUYPRNKLD2PIUKWV2LVVE6OJT4NDLM",
-            new BigDecimal(10));
+        Transaction transaction = kinAccount.buildTransactionSync("GBA2XHZRUAHEL4DZX7XNHR7HLBAUYPRNKLD2PIUKWV2LVVE6OJT4NDLM",
+                new BigDecimal(10));
+        kinAccount.sendTransactionSync(transaction);
     }
 
     @Test

--- a/kin-core/src/androidTest/kotlin/kin/core/FakeKinIssuer.kt
+++ b/kin-core/src/androidTest/kotlin/kin/core/FakeKinIssuer.kt
@@ -2,10 +2,10 @@ package kin.core
 
 
 import android.util.Log
-import junit.framework.Assert.assertTrue
 import kin.core.IntegConsts.TEST_NETWORK_URL
 import kin.core.IntegConsts.URL_CREATE_ACCOUNT
 import okhttp3.OkHttpClient
+import org.junit.Assert.assertTrue
 import org.stellar.sdk.*
 import java.io.IOException
 import java.util.concurrent.TimeUnit

--- a/kin-core/src/androidTest/kotlin/kin/core/FakeKinIssuer.kt
+++ b/kin-core/src/androidTest/kotlin/kin/core/FakeKinIssuer.kt
@@ -49,7 +49,7 @@ constructor() {
         val issuerAccountResponse = server.accounts().account(issuerKeyPair)
         val paymentOperation = PaymentOperation.Builder(destinationKeyPair, kinAsset, amount)
                 .build()
-        val transaction = Transaction.Builder(issuerAccountResponse)
+        val transaction = org.stellar.sdk.Transaction.Builder(issuerAccountResponse)
                 .addOperation(paymentOperation)
                 .build()
         transaction.sign(issuerKeyPair)

--- a/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
+++ b/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
@@ -139,9 +139,9 @@ class KinAccountIntegrationTest {
         val latch = CountDownLatch(1)
         val listenerRegistration = kinAccountReceiver.addPaymentListener { _ -> latch.countDown() }
 
-        val transactionId = kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"),
-                        memo)
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(),
+                BigDecimal("21.123"), memo)
+        val transactionId = kinAccountSender.sendTransactionSync(transaction)
         assertThat(kinAccountSender.balanceSync.value(), equalTo(BigDecimal("78.8770000")))
         assertThat(kinAccountReceiver.balanceSync.value(), equalTo(BigDecimal("21.1230000")))
 
@@ -149,8 +149,8 @@ class KinAccountIntegrationTest {
         listenerRegistration.remove()
 
         val server = Server(TEST_NETWORK_URL)
-        val transaction = server.transactions().transaction(transactionId.id())
-        val actualMemo = transaction.memo
+        val transactionResponse = server.transactions().transaction(transactionId.id())
+        val actualMemo = transactionResponse.memo
         assertThat<Memo>(actualMemo, `is`<Memo>(instanceOf<Memo>(MemoText::class.java)))
         assertThat((actualMemo as MemoText).text, equalTo(expectedMemo))
     }
@@ -165,8 +165,8 @@ class KinAccountIntegrationTest {
 
         expectedEx.expect(AccountNotFoundException::class.java)
         expectedEx.expectMessage(kinAccountReceiver.publicAddress)
-        kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        kinAccountSender.sendTransactionSync(transaction)
     }
 
     @Test
@@ -180,8 +180,8 @@ class KinAccountIntegrationTest {
 
         expectedEx.expect(AccountNotFoundException::class.java)
         expectedEx.expectMessage(kinAccountSender.publicAddress)
-        kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        kinAccountSender.sendTransactionSync(transaction)
     }
 
     @Test
@@ -192,8 +192,8 @@ class KinAccountIntegrationTest {
 
         expectedEx.expect(AccountNotActivatedException::class.java)
         expectedEx.expectMessage(kinAccountReceiver.publicAddress)
-        kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        kinAccountSender.sendTransactionSync(transaction)
     }
 
     @Test
@@ -209,8 +209,8 @@ class KinAccountIntegrationTest {
 
         expectedEx.expect(AccountNotActivatedException::class.java)
         expectedEx.expectMessage(kinAccountSender.publicAddress)
-        kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        kinAccountSender.sendTransactionSync(transaction)
     }
 
     @Test
@@ -257,8 +257,8 @@ class KinAccountIntegrationTest {
         fakeKinIssuer.fundWithKin(kinAccountSender.publicAddress.orEmpty(), "100")
         val memo = "memo"
         val expectedMemo = addAppIdToMemo(memo)
-        val expectedTransactionId = kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), transactionAmount, memo)
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), transactionAmount, memo)
+        val expectedTransactionId = kinAccountSender.sendTransactionSync(transaction)
 
         //verify data notified by listeners
         val transactionIndex = if (sender) 1 else 0 //in case of observing the sender we'll get 2 events (1 for funding 1 for the
@@ -290,8 +290,8 @@ class KinAccountIntegrationTest {
         }
         listenerRegistration.remove()
 
-        kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"), null)
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"), null)
+        kinAccountSender.sendTransactionSync(transaction)
 
         latch.await(15, TimeUnit.SECONDS)
     }
@@ -303,8 +303,8 @@ class KinAccountIntegrationTest {
         val (kinAccountSender, kinAccountReceiver) = onboardAccounts()
 
         expectedEx.expect(InsufficientKinException::class.java)
-        kinAccountSender
-                .sendTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        kinAccountSender.sendTransactionSync(transaction)
     }
 
     private fun onboardAccounts(activateSender: Boolean = true, activateReceiver: Boolean = true, senderFundAmount: Int = 0,

--- a/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
+++ b/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
@@ -155,19 +155,20 @@ class KinAccountIntegrationTest {
         assertThat((actualMemo as MemoText).text, equalTo(expectedMemo))
     }
 
-//    @Test
-//    @LargeTest
-//    @Throws(Exception::class)
-//    fun sendTransaction_ReceiverAccountNotCreated_AccountNotFoundException() {
-//        val kinAccountSender = kinClient.addAccount()
-//        val kinAccountReceiver = kinClient.addAccount()
-//        fakeKinIssuer.createAccount(kinAccountSender.publicAddress.orEmpty())
-//
-//        expectedEx.expect(AccountNotFoundException::class.java)
-//        expectedEx.expectMessage(kinAccountReceiver.publicAddress)
-//        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
-//        kinAccountSender.sendTransactionSync(transaction)
-//    }
+    @Test
+    @LargeTest
+    @Throws(Exception::class)
+    fun sendTransaction_ReceiverAccountNotCreated_AccountNotFoundException() {
+        val kinAccountSender = kinClient.addAccount()
+        val kinAccountReceiver = kinClient.addAccount()
+        fakeKinIssuer.createAccount(kinAccountSender.publicAddress.orEmpty())
+        kinAccountSender.activateSync()
+
+        expectedEx.expect(AccountNotFoundException::class.java)
+        expectedEx.expectMessage(kinAccountReceiver.publicAddress)
+        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+        kinAccountSender.sendTransactionSync(transaction)
+    }
 
     @Test
     @LargeTest
@@ -176,7 +177,7 @@ class KinAccountIntegrationTest {
         val kinAccountSender = kinClient.addAccount()
         val kinAccountReceiver = kinClient.addAccount()
         fakeKinIssuer.createAccount(kinAccountReceiver.publicAddress.orEmpty())
-        kinAccountReceiver.activateSync()
+//        kinAccountReceiver.activateSync()
 
         expectedEx.expect(AccountNotFoundException::class.java)
         expectedEx.expectMessage(kinAccountSender.publicAddress)

--- a/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
+++ b/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
@@ -155,19 +155,19 @@ class KinAccountIntegrationTest {
         assertThat((actualMemo as MemoText).text, equalTo(expectedMemo))
     }
 
-    @Test
-    @LargeTest
-    @Throws(Exception::class)
-    fun sendTransaction_ReceiverAccountNotCreated_AccountNotFoundException() {
-        val kinAccountSender = kinClient.addAccount()
-        val kinAccountReceiver = kinClient.addAccount()
-        fakeKinIssuer.createAccount(kinAccountSender.publicAddress.orEmpty())
-
-        expectedEx.expect(AccountNotFoundException::class.java)
-        expectedEx.expectMessage(kinAccountReceiver.publicAddress)
-        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
-        kinAccountSender.sendTransactionSync(transaction)
-    }
+//    @Test
+//    @LargeTest
+//    @Throws(Exception::class)
+//    fun sendTransaction_ReceiverAccountNotCreated_AccountNotFoundException() {
+//        val kinAccountSender = kinClient.addAccount()
+//        val kinAccountReceiver = kinClient.addAccount()
+//        fakeKinIssuer.createAccount(kinAccountSender.publicAddress.orEmpty())
+//
+//        expectedEx.expect(AccountNotFoundException::class.java)
+//        expectedEx.expectMessage(kinAccountReceiver.publicAddress)
+//        val transaction = kinAccountSender.buildTransactionSync(kinAccountReceiver.publicAddress.orEmpty(), BigDecimal("21.123"))
+//        kinAccountSender.sendTransactionSync(transaction)
+//    }
 
     @Test
     @LargeTest

--- a/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
+++ b/kin-core/src/androidTest/kotlin/kin/core/KinAccountIntegrationTest.kt
@@ -177,7 +177,6 @@ class KinAccountIntegrationTest {
         val kinAccountSender = kinClient.addAccount()
         val kinAccountReceiver = kinClient.addAccount()
         fakeKinIssuer.createAccount(kinAccountReceiver.publicAddress.orEmpty())
-//        kinAccountReceiver.activateSync()
 
         expectedEx.expect(AccountNotFoundException::class.java)
         expectedEx.expectMessage(kinAccountSender.publicAddress)

--- a/kin-core/src/main/java/kin/core/AbstractKinAccount.java
+++ b/kin-core/src/main/java/kin/core/AbstractKinAccount.java
@@ -9,24 +9,32 @@ abstract class AbstractKinAccount implements KinAccount {
 
     @NonNull
     @Override
-    public Request<TransactionId> sendTransaction(@NonNull final String publicAddress,
-        @NonNull final BigDecimal amount) {
-        return new Request<>(new Callable<TransactionId>() {
+    public Request<Transaction> buildTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount) {
+        return new Request<>(new Callable<Transaction>() {
             @Override
-            public TransactionId call() throws Exception {
-                return sendTransactionSync(publicAddress, amount, null);
+            public Transaction call() throws Exception {
+                return buildTransactionSync(publicAddress, amount);
+            }
+        });
+    }@NonNull
+    @Override
+    public Request<Transaction> buildTransaction(@NonNull final String publicAddress,
+                                                 @NonNull final BigDecimal amount, @Nullable final String memo) {
+        return new Request<>(new Callable<Transaction>() {
+            @Override
+            public Transaction call() throws Exception {
+                return buildTransactionSync(publicAddress, amount, memo);
             }
         });
     }
 
     @NonNull
     @Override
-    public Request<TransactionId> sendTransaction(@NonNull final String publicAddress, @NonNull final BigDecimal amount,
-        @Nullable final String memo) {
+    public Request<TransactionId> sendTransaction(final Transaction transaction) {
         return new Request<>(new Callable<TransactionId>() {
             @Override
             public TransactionId call() throws Exception {
-                return sendTransactionSync(publicAddress, amount, memo);
+                return sendTransactionSync(transaction);
             }
         });
     }

--- a/kin-core/src/main/java/kin/core/KinAccount.java
+++ b/kin-core/src/main/java/kin/core/KinAccount.java
@@ -21,38 +21,65 @@ public interface KinAccount {
     String getPublicAddress();
 
     /**
-     * Create {@link Request} for signing and sending a transaction of the given amount in kin, to the specified public
-     * address
-     * <p> See {@link KinAccount#sendTransactionSync(String, BigDecimal)} for possibles errors</p>
-     *
+     * Build a Transaction object of the given amount in kin, to the specified public address.
+     * <p> See {@link KinAccount#buildTransactionSync(String, BigDecimal)} for possibles errors</p>
      * @param publicAddress the account address to send the specified kin amount
      * @param amount the amount of kin to transfer
      * @return {@code Request<TransactionId>}, TransactionId - the transaction identifier
      */
-    @NonNull
-    Request<TransactionId> sendTransaction(@NonNull String publicAddress, @NonNull BigDecimal amount);
+    Request<Transaction> buildTransaction(@NonNull String publicAddress, @NonNull BigDecimal amount);
 
     /**
-     * Create {@link Request} for signing and sending a transaction of the given amount in kin, to the specified public
-     * address
-     * <p> See {@link KinAccount#sendTransactionSync(String, BigDecimal)} for possibles errors</p>
-     *
+     * Build a Transaction object of the given amount in kin, to the specified public address and with a memo(that can be empty or null).
+     * <p> See {@link KinAccount#buildTransaction(String, BigDecimal, String)} for possibles errors</p>
      * @param publicAddress the account address to send the specified kin amount
      * @param amount the amount of kin to transfer
-     * @param memo An optional string, can contain a utf-8 string up to 28 bytes in length, included on the transaction
-     * record.
+     * @param memo An optional string, can contain a utf-8 string up to 28 bytes in length, included on the transaction record.
      * @return {@code Request<TransactionId>}, TransactionId - the transaction identifier
      */
-    @NonNull
-    Request<TransactionId> sendTransaction(@NonNull String publicAddress, @NonNull BigDecimal amount,
-        @Nullable String memo);
+    Request<Transaction> buildTransaction(@NonNull String publicAddress, @NonNull BigDecimal amount, @Nullable String memo);
 
     /**
-     * Create, sign and send a transaction of the given amount in kin to the specified public address
+     * Create {@link Request} for signing and sending a transaction
+     * <p> See {@link KinAccount#sendTransactionSync(Transaction)} for possibles errors</p>
+     * @param transaction is the transaction object to send.
+     * @return {@code Request<TransactionId>}, TransactionId - the transaction identifier.
+     */
+    @NonNull
+    Request<TransactionId> sendTransaction(Transaction transaction);
+
+    /**
+     * Build a Transaction object of the given amount in kin, to the specified public address.
      * <p><b>Note:</b> This method accesses the network, and should not be called on the android main thread.</p>
      *
      * @param publicAddress the account address to send the specified kin amount
      * @param amount the amount of kin to transfer
+     * @return a Transaction object which also includes the transaction id.
+     * @throws AccountNotFoundException if the sender or destination account was not created
+     * @throws AccountNotActivatedException if the sender or destination account is not activated
+     * @throws OperationFailedException other error occurred
+     */
+    Transaction buildTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount) throws OperationFailedException;
+
+    /**
+     * Build a Transaction object of the given amount in kin, to the specified public address and with a memo(that can be empty or null).
+     * <p><b>Note:</b> This method accesses the network, and should not be called on the android main thread.</p>
+     *
+     * @param publicAddress the account address to send the specified kin amount
+     * @param amount the amount of kin to transfer
+     * @param memo An optional string, can contain a utf-8 string up to 28 bytes in length, included on the transaction record.
+     * @return a Transaction object which also includes the transaction id.
+     * @throws AccountNotFoundException if the sender or destination account was not created
+     * @throws AccountNotActivatedException if the sender or destination account is not activated
+     * @throws OperationFailedException other error occurred
+     */
+    Transaction buildTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount, @Nullable String memo) throws OperationFailedException;
+
+    /**
+     * send a transaction.
+     * <p><b>Note:</b> This method accesses the network, and should not be called on the android main thread.</p>
+     *
+     * @param transaction is the transaction object to send.
      * @return TransactionId the transaction identifier
      * @throws AccountNotFoundException if the sender or destination account was not created
      * @throws AccountNotActivatedException if the sender or destination account is not activated
@@ -61,27 +88,7 @@ public interface KinAccount {
      * @throws OperationFailedException other error occurred
      */
     @NonNull
-    TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount)
-        throws OperationFailedException;
-
-    /**
-     * Create, sign and send a transaction of the given amount in kin to the specified public address
-     * <p><b>Note:</b> This method accesses the network, and should not be called on the android main thread.</p>
-     *
-     * @param publicAddress the account address to send the specified kin amount
-     * @param amount the amount of kin to transfer
-     * @param memo An optional string, can contain a utf-8 string up to 28 bytes in length, included on the transaction
-     * record.
-     * @return TransactionId the transaction identifier
-     * @throws AccountNotFoundException if the sender or destination account was not created
-     * @throws AccountNotActivatedException if the sender or destination account is not activated
-     * @throws InsufficientKinException if account balance has not enough kin
-     * @throws TransactionFailedException if transaction failed, contains blockchain failure details
-     * @throws OperationFailedException other error occurred
-     */
-    @NonNull
-    TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount, @Nullable String memo)
-        throws OperationFailedException;
+    TransactionId sendTransactionSync(Transaction transaction) throws OperationFailedException;
 
     /**
      * Create {@link Request} for getting the current confirmed balance in kin

--- a/kin-core/src/main/java/kin/core/KinAccountImpl.java
+++ b/kin-core/src/main/java/kin/core/KinAccountImpl.java
@@ -34,21 +34,40 @@ final class KinAccountImpl extends AbstractKinAccount {
         return null;
     }
 
-    @NonNull
     @Override
-    public TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount)
-        throws OperationFailedException {
+    public Transaction buildTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount) throws OperationFailedException {
         checkValidAccount();
-        return transactionSender.sendTransaction(account, publicAddress, amount);
+        return transactionSender.buildTransaction(account, publicAddress, amount);
+    }
+
+    @Override
+    public Transaction buildTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount, @Nullable String memo) throws OperationFailedException {
+        checkValidAccount();
+        return transactionSender.buildTransaction(account, publicAddress, amount, memo);
     }
 
     @NonNull
     @Override
-    public TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount,
-        @Nullable String memo) throws OperationFailedException {
+    public TransactionId sendTransactionSync(Transaction transaction) throws OperationFailedException {
         checkValidAccount();
-        return transactionSender.sendTransaction(account, publicAddress, amount, memo);
+        return transactionSender.sendTransaction(transaction);
     }
+
+//    @NonNull
+//    @Override
+//    public TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount)
+//        throws OperationFailedException {
+//        checkValidAccount();
+//        return transactionSender.sendTransaction(account, publicAddress, amount);
+//    }
+//
+//    @NonNull
+//    @Override
+//    public TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount,
+//        @Nullable String memo) throws OperationFailedException {
+//        checkValidAccount();
+//        return transactionSender.sendTransaction(account, publicAddress, amount, memo);
+//    }
 
     @NonNull
     @Override

--- a/kin-core/src/main/java/kin/core/KinAccountImpl.java
+++ b/kin-core/src/main/java/kin/core/KinAccountImpl.java
@@ -53,22 +53,6 @@ final class KinAccountImpl extends AbstractKinAccount {
         return transactionSender.sendTransaction(transaction);
     }
 
-//    @NonNull
-//    @Override
-//    public TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount)
-//        throws OperationFailedException {
-//        checkValidAccount();
-//        return transactionSender.sendTransaction(account, publicAddress, amount);
-//    }
-//
-//    @NonNull
-//    @Override
-//    public TransactionId sendTransactionSync(@NonNull String publicAddress, @NonNull BigDecimal amount,
-//        @Nullable String memo) throws OperationFailedException {
-//        checkValidAccount();
-//        return transactionSender.sendTransaction(account, publicAddress, amount, memo);
-//    }
-
     @NonNull
     @Override
     public Balance getBalanceSync() throws OperationFailedException {

--- a/kin-core/src/main/java/kin/core/Transaction.java
+++ b/kin-core/src/main/java/kin/core/Transaction.java
@@ -1,0 +1,62 @@
+package kin.core;
+
+import org.stellar.sdk.KeyPair;
+
+import java.math.BigDecimal;
+
+public class Transaction {
+
+    /**
+     * Destination key pair.
+     */
+    private final KeyPair destination;
+    /**
+     * Source account key pair.
+     */
+    private final KeyPair source;
+
+    private final BigDecimal amount;
+    private final String memo;
+
+    /**
+     * The transaction hash
+     */
+    private final String id;
+
+    private final org.stellar.sdk.Transaction stellarTransaction;
+
+    public Transaction(KeyPair destination, KeyPair source, BigDecimal amount,
+                       String memo, String id, org.stellar.sdk.Transaction stellarTransaction) {
+        this.destination = destination;
+        this.source = source;
+        this.amount = amount;
+        this.memo = memo;
+        this.id = id; // TODO: 23/10/2018 maybe use TransactionId object here in order to keep it like today? or maybe delete TransactionId?
+        this.stellarTransaction = stellarTransaction;  // TODO: 23/10/2018 create a better name
+    }
+
+    public KeyPair getDestination() {
+        return destination;
+    }
+
+    public KeyPair getSource() {
+        return source;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+
+    org.stellar.sdk.Transaction getStellarTransaction() {
+        return stellarTransaction;
+    }
+}

--- a/kin-core/src/main/java/kin/core/Transaction.java
+++ b/kin-core/src/main/java/kin/core/Transaction.java
@@ -6,13 +6,7 @@ import java.math.BigDecimal;
 
 public class Transaction {
 
-    /**
-     * Destination key pair.
-     */
     private final KeyPair destination;
-    /**
-     * Source account key pair.
-     */
     private final KeyPair source;
 
     private final BigDecimal amount;
@@ -25,7 +19,7 @@ public class Transaction {
 
     private final org.stellar.sdk.Transaction stellarTransaction;
 
-    public Transaction(KeyPair destination, KeyPair source, BigDecimal amount,
+    Transaction(KeyPair destination, KeyPair source, BigDecimal amount,
                        String memo, TransactionId id, org.stellar.sdk.Transaction stellarTransaction) {
         this.destination = destination;
         this.source = source;

--- a/kin-core/src/main/java/kin/core/Transaction.java
+++ b/kin-core/src/main/java/kin/core/Transaction.java
@@ -21,18 +21,18 @@ public class Transaction {
     /**
      * The transaction hash
      */
-    private final String id;
+    private final TransactionId id;
 
     private final org.stellar.sdk.Transaction stellarTransaction;
 
     public Transaction(KeyPair destination, KeyPair source, BigDecimal amount,
-                       String memo, String id, org.stellar.sdk.Transaction stellarTransaction) {
+                       String memo, TransactionId id, org.stellar.sdk.Transaction stellarTransaction) {
         this.destination = destination;
         this.source = source;
         this.amount = amount;
         this.memo = memo;
-        this.id = id; // TODO: 23/10/2018 maybe use TransactionId object here in order to keep it like today? or maybe delete TransactionId?
-        this.stellarTransaction = stellarTransaction;  // TODO: 23/10/2018 create a better name
+        this.id = id;
+        this.stellarTransaction = stellarTransaction;
     }
 
     public KeyPair getDestination() {
@@ -51,7 +51,7 @@ public class Transaction {
         return memo;
     }
 
-    public String getId() {
+    public TransactionId getId() {
         return id;
     }
 

--- a/kin-core/src/main/java/kin/core/TransactionSender.java
+++ b/kin-core/src/main/java/kin/core/TransactionSender.java
@@ -173,7 +173,6 @@ class TransactionSender {
     @NonNull
     private TransactionId sendTransaction(org.stellar.sdk.Transaction transaction) throws OperationFailedException {
         try {
-            byte[] hash = transaction.hash();
             SubmitTransactionResponse response = server.submitTransaction(transaction);
             if (response == null) {
                 throw new OperationFailedException("can't get transaction response");

--- a/kin-core/src/main/java/kin/core/TransactionSender.java
+++ b/kin-core/src/main/java/kin/core/TransactionSender.java
@@ -52,8 +52,8 @@ class TransactionSender {
         KeyPair addressee = generateAddresseeKeyPair(publicAddress);
         AccountResponse sourceAccount = loadSourceAccount(from);
         org.stellar.sdk.Transaction stellarTransaction = buildStellarTransaction(from, amount, addressee, sourceAccount, memo);
-        return new Transaction(addressee, from, amount, memo,
-               Utils.byteArrayToHex(stellarTransaction.hash()), stellarTransaction); // TODO: 25/10/2018 maybe change it from stellarTransaction to something else?
+        TransactionId id = new TransactionIdImpl(Utils.byteArrayToHex(stellarTransaction.hash()));
+        return new Transaction(addressee, from, amount, memo, id, stellarTransaction);
     }
 
     TransactionId sendTransaction(Transaction transaction) throws OperationFailedException {
@@ -174,7 +174,6 @@ class TransactionSender {
     private TransactionId sendTransaction(org.stellar.sdk.Transaction transaction) throws OperationFailedException {
         try {
             byte[] hash = transaction.hash();
-            Log.d("TEST", "sendTransaction: our hash = " + Utils.byteArrayToHex(hash)); // TODO: 22/10/2018 delete before push
             SubmitTransactionResponse response = server.submitTransaction(transaction);
             if (response == null) {
                 throw new OperationFailedException("can't get transaction response");

--- a/kin-core/src/main/java/kin/core/Utils.java
+++ b/kin-core/src/main/java/kin/core/Utils.java
@@ -25,6 +25,13 @@ final class Utils {
         return new TransactionFailedException(transactionResultCode, operationsResultCodes);
     }
 
+    static String byteArrayToHex(byte[] a) {
+        StringBuilder sb = new StringBuilder(a.length * 2);
+        for(byte b : a)
+            sb.append(String.format("%02x", b));
+        return sb.toString();
+    }
+
     static void checkNotNull(Object obj, String paramName) {
         if (obj == null) {
             throw new IllegalArgumentException(paramName + " == null");

--- a/kin-core/src/test/java/kin/core/KinAccountImplTest.java
+++ b/kin-core/src/test/java/kin/core/KinAccountImplTest.java
@@ -54,14 +54,12 @@ public class KinAccountImplTest {
         BigDecimal expectedAmount = new BigDecimal("12.2");
         TransactionId expectedTransactionId = new TransactionIdImpl("myId");
 
-        when(mockTransactionSender.sendTransaction((KeyPair) any(), (String) any(), (BigDecimal) any()))
-            .thenReturn(expectedTransactionId);
+        when(mockTransactionSender.sendTransaction((Transaction) any())).thenReturn(expectedTransactionId);
 
-        TransactionId transactionId = kinAccount
-            .sendTransactionSync(expectedAccountId, expectedAmount);
+        Transaction transaction = kinAccount.buildTransactionSync(expectedAccountId, expectedAmount);
+        TransactionId transactionId = kinAccount.sendTransactionSync(transaction);
 
-        verify(mockTransactionSender)
-            .sendTransaction(expectedRandomAccount, expectedAccountId, expectedAmount);
+        verify(mockTransactionSender).sendTransaction(transaction);
         assertEquals(expectedTransactionId, transactionId);
     }
 
@@ -74,15 +72,12 @@ public class KinAccountImplTest {
         TransactionId expectedTransactionId = new TransactionIdImpl("myId");
         String memo = "Dummy Memo";
 
-        when(mockTransactionSender
-            .sendTransaction((KeyPair) any(), anyString(), (BigDecimal) any(), anyString()))
-            .thenReturn(expectedTransactionId);
+        when(mockTransactionSender.sendTransaction((Transaction) any())).thenReturn(expectedTransactionId);
 
-        TransactionId transactionId = kinAccount
-            .sendTransactionSync(expectedAccountId, expectedAmount, memo);
+        Transaction transaction = kinAccount.buildTransactionSync(expectedAccountId, expectedAmount, memo);
+        TransactionId transactionId = kinAccount.sendTransactionSync(transaction);
 
-        verify(mockTransactionSender)
-            .sendTransaction(expectedRandomAccount, expectedAccountId, expectedAmount, memo);
+        verify(mockTransactionSender).sendTransaction(transaction);
         assertEquals(expectedTransactionId, transactionId);
     }
 
@@ -125,8 +120,8 @@ public class KinAccountImplTest {
         initWithRandomAccount();
         kinAccount.markAsDeleted();
 
-        kinAccount
-            .sendTransactionSync("GDKJAMCTGZGD6KM7RBEII6QUYAHQQUGERXKM3ESHBX2UUNTNAVNB3OGX", new BigDecimal("12.2"));
+        Transaction transaction = kinAccount.buildTransactionSync("GDKJAMCTGZGD6KM7RBEII6QUYAHQQUGERXKM3ESHBX2UUNTNAVNB3OGX", new BigDecimal("12.2"));
+        kinAccount.sendTransactionSync(transaction);
     }
 
     @Test(expected = AccountDeletedException.class)

--- a/sample/src/main/java/kin/core/sample/TransactionActivity.java
+++ b/sample/src/main/java/kin/core/sample/TransactionActivity.java
@@ -151,7 +151,7 @@ public class TransactionActivity extends BaseActivity {
             buildTransactionRequest.run(new ResultCallback<Transaction>() {
                 @Override
                 public void onResult(Transaction transaction) {
-                    Log.d(TAG, "sendTransaction: build transaction " + transaction.getId() + " succeeded");
+                    Log.d(TAG, "sendTransaction: build transaction " + transaction.getId().id() + " succeeded");
                     sendTransactionRequest = account.sendTransaction(transaction);
                     sendTransactionRequest.run(callback);
                 }

--- a/sample/src/main/java/kin/core/sample/TransactionActivity.java
+++ b/sample/src/main/java/kin/core/sample/TransactionActivity.java
@@ -6,11 +6,14 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.View;
 import android.widget.EditText;
 import java.math.BigDecimal;
 import kin.core.KinAccount;
 import kin.core.Request;
+import kin.core.ResultCallback;
+import kin.core.Transaction;
 import kin.core.TransactionId;
 import kin.core.exception.AccountDeletedException;
 import kin.core.exception.OperationFailedException;
@@ -30,7 +33,8 @@ public class TransactionActivity extends BaseActivity {
     private View sendTransaction, progressBar;
 
     private EditText toAddressInput, amountInput, memoInput;
-    private Request<TransactionId> transactionRequest;
+    private Request<Transaction> buildTransactionRequest;
+    private Request<TransactionId> sendTransactionRequest;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -139,11 +143,25 @@ public class TransactionActivity extends BaseActivity {
                 }
             };
             if (memo == null) {
-                transactionRequest = account.sendTransaction(toAddress, amount);
+                buildTransactionRequest = account.buildTransaction(toAddress, amount);
+
             } else {
-                transactionRequest = account.sendTransaction(toAddress, amount, memo);
+                buildTransactionRequest = account.buildTransaction(toAddress, amount, memo);
             }
-            transactionRequest.run(callback);
+            buildTransactionRequest.run(new ResultCallback<Transaction>() {
+                @Override
+                public void onResult(Transaction transaction) {
+                    Log.d(TAG, "sendTransaction: build transaction " + transaction.getId() + " succeeded");
+                    sendTransactionRequest = account.sendTransaction(transaction);
+                    sendTransactionRequest.run(callback);
+                }
+
+                @Override
+                public void onError(Exception e) {
+                    Utils.logError(e, "sendTransaction");
+                    KinAlertDialog.createErrorDialog(TransactionActivity.this, e.getMessage()).show();
+                }
+            });
         } else {
             progressBar.setVisibility(View.GONE);
             throw new AccountDeletedException();
@@ -153,8 +171,11 @@ public class TransactionActivity extends BaseActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (transactionRequest != null) {
-            transactionRequest.cancel(false);
+        if (buildTransactionRequest != null) {
+            buildTransactionRequest.cancel(false);
+        }
+        if (sendTransactionRequest != null) {
+            sendTransactionRequest.cancel(false);
         }
         progressBar = null;
     }


### PR DESCRIPTION
Add the option for users to get the transaction id(hash) before even sending the transaction.