### PR TITLE
DP-217 - initialize native libsodium lazily

### DIFF
--- a/kin-core/src/main/java/kin/core/BackupRestoreImpl.java
+++ b/kin-core/src/main/java/kin/core/BackupRestoreImpl.java
@@ -18,16 +18,13 @@ class BackupRestoreImpl implements BackupRestore {
     private static final int SALT_LENGTH_BYTES = 16;
     private static final int HASH_LENGTH_BYTES = 32;
     private static final int OUPUT_JSON_INDENT_SPACES = 2;
-
-    BackupRestoreImpl() {
-        //init sodium
-        NaCl.sodium();
-    }
+    private boolean initialized = false;
 
     @Override
     @NonNull
     public String exportWallet(@NonNull KeyPair keyPair, @NonNull String passphrase)
         throws CryptoException {
+        initIfNeeded();
         byte[] saltBytes = generateRandomBytes(SALT_LENGTH_BYTES);
 
         byte[] passphraseBytes = stringToUTF8ByteArray(passphrase);
@@ -41,10 +38,18 @@ class BackupRestoreImpl implements BackupRestore {
         return jsonify(keyPair.getAccountId(), salt, seed);
     }
 
+    private void initIfNeeded() {
+        if (!initialized) {
+            NaCl.sodium();
+            initialized = true;
+        }
+    }
+
     @Override
     @NonNull
     public KeyPair importWallet(@NonNull String exportedJson, @NonNull String passphrase)
         throws CryptoException, CorruptedDataException {
+        initIfNeeded();
         AccountJson accountJson = stringify(exportedJson);
 
         byte[] passphraseBytes = stringToUTF8ByteArray(passphrase);

--- a/run_integ_test.sh
+++ b/run_integ_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+if [ -z "$1" ]
+then
+    echo "Please specify AVD name to test on."
+    exit 1
+fi
+
+git clone https://github.com/kinecosystem/blockchain-ops.git
+cd blockchain-ops
+git checkout c26afdc168ad378363c63fb44de5a93b3cf24ddf
+cd image
+./init.sh
+cd ../..
+~/Library/Android/sdk/tools/emulator -avd $1 &
+
+#wait for emulator
+set +e
+
+bootanim=""
+failcounter=0
+timeout_in_sec=360
+
+until [[ "$bootanim" =~ "stopped" ]]; do
+  bootanim=`adb -e shell getprop init.svc.bootanim 2>&1 &`
+  if [[ "$bootanim" =~ "device not found" || "$bootanim" =~ "device offline"
+    || "$bootanim" =~ "running" ]]; then
+    let "failcounter += 1"
+    echo "Waiting for emulator to start"
+    if [[ $failcounter -gt timeout_in_sec ]]; then
+      echo "Timeout ($timeout_in_sec seconds) reached; failed to start emulator"
+      exit 1
+    fi
+  fi
+  sleep 1
+done
+
+echo "Emulator is ready"
+#---------------------
+./gradlew jacocoTestReport
+if [ $? -eq 0 ]; then
+    open kin-core/build/reports/jacoco/jacocoTestReport/html/index.html
+else
+    echo Build failed!
+fi


### PR DESCRIPTION
* prevent cases with some old Samsung devices where libsodium cannot be
loaded and that rendered the sdk useless.
* add local script for running android test (as they can't be ran on CI
since including native lib), taken from v2 branch.