### PR TITLE
DP-226 fix proguard errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,16 +39,10 @@ before_script:
   - emulator -avd test -no-skin -no-audio -no-window -camera-back none -camera-front none -verbose -memory 2048 &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
-  - git clone https://github.com/kinecosystem/blockchain-ops.git
-  - cd blockchain-ops
-  # use specific working version to ensure it will not break in the future
-  - git checkout c26afdc168ad378363c63fb44de5a93b3cf24ddf
-  - cd image
-  - ./init.sh
 
 script:
   - cd ../..
-  - ./gradlew :sample:assembleDebug
+  - ./gradlew assemble
   - ./gradlew testDebugUnitTest
   #- ./gradlew jacocoTestReport  -Pandroid.testInstrumentationRunnerArguments.notClass=kin.core.KinAccountIntegrationTest --info
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ before_script:
   - adb shell input keyevent 82 &
 
 script:
-  - cd ../..
   - ./gradlew assemble
   - ./gradlew testDebugUnitTest
   #- ./gradlew jacocoTestReport  -Pandroid.testInstrumentationRunnerArguments.notClass=kin.core.KinAccountIntegrationTest --info


### PR DESCRIPTION
* add proguard rule to android-stellar-sdk (see https://github.com/kinecosystem/android-stellar-sdk/pull/23)
* build release in travis for testing proguard compilation.
* remove local blockchain init, we're testing against kin playground network.