### PR TITLE
import account and add only if not exists

### DIFF
--- a/kin-core/src/androidTest/java/kin/core/KinClientIntegrationTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinClientIntegrationTest.java
@@ -312,25 +312,28 @@ public class KinClientIntegrationTest {
 
     @Test
     public void importAccount_AddOnlyIfNotExists() throws Exception {
+        kinClient.addAccount();
+        kinClient.addAccount();
+        kinClient.addAccount();
         KinAccount kinAccount = kinClient.addAccount();
-        String uuid = UUID.randomUUID().toString();
-        String exported = kinAccount.export(uuid);
-        kinClient.importAccount(exported, uuid);
-        assertEquals(1, kinClient.getAccountCount());
+        String passphrase = UUID.randomUUID().toString();
+        String exported = kinAccount.export(passphrase);
+        kinClient.importAccount(exported, passphrase);
+        assertEquals(4, kinClient.getAccountCount());
     }
 
     @Test
     public void importAccount_AddNewAccount() throws Exception {
         KinAccount kinAccount = kinClient.addAccount();
-        String uuid = UUID.randomUUID().toString();
-        String exported = kinAccount.export(uuid);
-        kinClient.importAccount(exported, uuid);
+        String passphrase = UUID.randomUUID().toString();
+        String exported = kinAccount.export(passphrase);
+        kinClient.importAccount(exported, passphrase);
         assertEquals(1, kinClient.getAccountCount());
 
         kinClient.clearAllAccounts();
         assertEquals(0, kinClient.getAccountCount());
 
-        kinClient.importAccount(exported, uuid);
+        kinClient.importAccount(exported, passphrase);
         assertEquals(1, kinClient.getAccountCount());
     }
 

--- a/kin-core/src/androidTest/java/kin/core/KinClientIntegrationTest.java
+++ b/kin-core/src/androidTest/java/kin/core/KinClientIntegrationTest.java
@@ -310,6 +310,30 @@ public class KinClientIntegrationTest {
         }
     }
 
+    @Test
+    public void importAccount_AddOnlyIfNotExists() throws Exception {
+        KinAccount kinAccount = kinClient.addAccount();
+        String uuid = UUID.randomUUID().toString();
+        String exported = kinAccount.export(uuid);
+        kinClient.importAccount(exported, uuid);
+        assertEquals(1, kinClient.getAccountCount());
+    }
+
+    @Test
+    public void importAccount_AddNewAccount() throws Exception {
+        KinAccount kinAccount = kinClient.addAccount();
+        String uuid = UUID.randomUUID().toString();
+        String exported = kinAccount.export(uuid);
+        kinClient.importAccount(exported, uuid);
+        assertEquals(1, kinClient.getAccountCount());
+
+        kinClient.clearAllAccounts();
+        assertEquals(0, kinClient.getAccountCount());
+
+        kinClient.importAccount(exported, uuid);
+        assertEquals(1, kinClient.getAccountCount());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void initKinClient_NullId_Exception() {
         kinClient = createNewKinClient(null);

--- a/kin-core/src/main/java/kin/core/KinClient.java
+++ b/kin-core/src/main/java/kin/core/KinClient.java
@@ -4,19 +4,16 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-
-import org.stellar.sdk.KeyPair;
-import org.stellar.sdk.Network;
-import org.stellar.sdk.Server;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import kin.core.exception.CorruptedDataException;
 import kin.core.exception.CreateAccountException;
 import kin.core.exception.CryptoException;
 import kin.core.exception.DeleteAccountException;
+import org.stellar.sdk.KeyPair;
+import org.stellar.sdk.Network;
+import org.stellar.sdk.Server;
 
 /**
  * An account manager for a {@link KinAccount}.
@@ -38,7 +35,7 @@ public class KinClient {
     /**
      * KinClient is an account manager for a {@link KinAccount}.
      *
-     * @param context  the android application context
+     * @param context the android application context
      * @param provider the service provider - provides blockchain network parameters
      * @param storeKey the key for storing this client data, different keys will store a different accounts
      */
@@ -59,7 +56,7 @@ public class KinClient {
     /**
      * KinClient is an account manager for a {@link KinAccount}.
      *
-     * @param context  the android application context
+     * @param context the android application context
      * @param provider the service provider - provides blockchain network parameters
      */
     public KinClient(@NonNull Context context, @NonNull ServiceProvider provider) {
@@ -68,8 +65,8 @@ public class KinClient {
 
     @VisibleForTesting
     KinClient(ServiceProvider serviceProvider, KeyStore keyStore, TransactionSender transactionSender,
-              AccountActivator accountActivator, AccountInfoRetriever accountInfoRetriever,
-              BlockchainEventsCreator blockchainEventsCreator, BackupRestore backupRestore) {
+        AccountActivator accountActivator, AccountInfoRetriever accountInfoRetriever,
+        BlockchainEventsCreator blockchainEventsCreator, BackupRestore backupRestore) {
         this.serviceProvider = serviceProvider;
         this.keyStore = keyStore;
         this.transactionSender = transactionSender;
@@ -87,7 +84,7 @@ public class KinClient {
 
     private KeyStore initKeyStore(Context context, String id) {
         SharedPrefStore store = new SharedPrefStore(
-                context.getSharedPreferences(STORE_NAME_PREFIX + id, Context.MODE_PRIVATE));
+            context.getSharedPreferences(STORE_NAME_PREFIX + id, Context.MODE_PRIVATE));
         return new KeyStoreImpl(store, backupRestore);
     }
 
@@ -137,7 +134,7 @@ public class KinClient {
     private KinAccount getAccountByPublicAddress(String accountId) {
         KinAccount kinAccount = null;
         for (int i = 0; i < kinAccounts.size(); i++) {
-            final KinAccount account = kinAccounts.get(0);
+            final KinAccount account = kinAccounts.get(i);
             if (accountId.equals(account.getPublicAddress())) {
                 kinAccount = account;
             }
@@ -209,7 +206,7 @@ public class KinClient {
     @NonNull
     private KinAccountImpl createNewKinAccount(KeyPair account) {
         return new KinAccountImpl(account, backupRestore, transactionSender, accountActivator, accountInfoRetriever,
-                blockchainEventsCreator);
+            blockchainEventsCreator);
     }
 
 }


### PR DESCRIPTION
Import account was always adding the account to the list, although it has this account.

So now it will search on the account return if the relevant account if exists. 